### PR TITLE
Fixed the height of the images on home screen

### DIFF
--- a/src/containers/Home/Home.scss
+++ b/src/containers/Home/Home.scss
@@ -49,6 +49,7 @@
     img.chart {
       margin-right: 2em;
       width: 260px;
+      height: 100%;
     }
   }
 
@@ -58,6 +59,7 @@
 
     img.key-pair {
       width: 400px;
+      height: 100%;
     }
   }
 


### PR DESCRIPTION
Both the "Comparison char of TX times" and "Key Pair" looked elongated and squished on small screen devices. I changed their height to 100% so their dimension becomes normal.