### PR TITLE
Removed the margin from marketing buttons

### DIFF
--- a/src/containers/Home/Home.scss
+++ b/src/containers/Home/Home.scss
@@ -37,7 +37,7 @@ $section-padding: 24px 42px;
     .marketing-buttons {
       display: flex;
       justify-content: center;
-      margin: 24px 36px 0 0;
+      margin: 24px 0 0 0;
 
       .MarketingButton {
         margin: 0 8px;


### PR DESCRIPTION
The 36px margin on the right caused the marketing buttons to look off-centre on both Desktop and smartphone.