### PR TITLE
A part of Issue #70 resolved

### DIFF
--- a/src/containers/AdminLayout/AdminLayout.scss
+++ b/src/containers/AdminLayout/AdminLayout.scss
@@ -10,7 +10,7 @@
 
   .top {
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-    grid-column: 2 / span 1;
+    grid-column: 1 / span 2;
     grid-row: 1 / span 1;
 
     .TopNav {
@@ -61,6 +61,7 @@
   }
 
   .left {
+    margin-top: 46px;
     background: #26252b;
     box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.1);
     grid-column: 1 / span 1;


### PR DESCRIPTION
After this change, Top Navbar floats above the Left Menu and does not shift to the right. Easy to open and close the Left Menu on small screen devices.

![Desktop](https://user-images.githubusercontent.com/55133485/87907228-d288e400-ca81-11ea-9ef2-8c3b3551b584.JPG)
![Responsive](https://user-images.githubusercontent.com/55133485/87907241-d7e62e80-ca81-11ea-8e0a-43a7077755fd.JPG)
