### PR TITLE
close mobile nav menu on page switch

### DIFF
--- a/src/containers/AdminLayout/index.tsx
+++ b/src/containers/AdminLayout/index.tsx
@@ -21,6 +21,9 @@ export const AdminLayout: FC<ComponentProps> = ({left, right}) => {
 
   useEffect(() => {
     rightDiv.current?.scrollTo(0, 0);
+    if (window.innerWidth < 768) {
+      toggleLeftMenuOpen(false);
+    }
   }, [pathname]);
 
   return (


### PR DESCRIPTION
On mobile, when switching to a different page via the left nav / hamburger menu, the menu remains open but I think it's expected behavior for it to close (so visitors don't have to manually close it in order to read what is on that next page). Adding `toggleLeftMenuOpen(false)` to the AdminLayout's 2nd useEffect (taking the pathname argument) successfully does the trick, but doesn't work well on desktop since you'd expect it to remain open. So that's why it exists inside an if statement taking the screen width into consideration. Screen recording demonstrating the change: https://imgur.com/a/ZvcJ48t