### PR TITLE
Added z-index on TopNav

### DIFF
--- a/src/components/TopNav/TopNav.scss
+++ b/src/components/TopNav/TopNav.scss
@@ -3,6 +3,7 @@
   background: white;
   display: flex;
   height: 60px;
+  z-index: 1;
 
   &__download-button {
     margin-right: 24px;


### PR DESCRIPTION
The TopNav shadow disappeared when scrolled upon "HomeInstantTransactions" section

![Group 1 (2)](https://user-images.githubusercontent.com/55133485/94262765-9aa28f00-ff51-11ea-9d86-50f88a4c854a.png)