### PR TITLE
resolve page moved horizontally

### DIFF
--- a/src/components/Table/TableVertical/TableVertical.scss
+++ b/src/components/Table/TableVertical/TableVertical.scss
@@ -1,25 +1,28 @@
-.TableVertical {
-  border: 1px solid #e6e6e6;
-  margin-bottom: 20px;
+.TableVerticalWrapper {
+  overflow-x: auto;
+  .TableVertical {
+    border: 1px solid #e6e6e6;
+    margin-bottom: 20px;
 
-  &__tr {
-    &--even {
-      background: #f6f6f6;
-    }
-  }
-
-  &__td {
-    min-width: 90px;
-    padding: 2px 8px;
-
-    &:first-child {
-      font-weight: 700;
-      padding-right: 16px;
-      white-space: nowrap;
+    &__tr {
+      &--even {
+        background: #f6f6f6;
+      }
     }
 
-    &--border {
-      border: 1px solid #e6e6e6;
+    &__td {
+      min-width: 90px;
+      padding: 2px 8px;
+
+      &:first-child {
+        font-weight: 700;
+        padding-right: 16px;
+        white-space: nowrap;
+      }
+
+      &--border {
+        border: 1px solid #e6e6e6;
+      }
     }
   }
 }

--- a/src/components/Table/TableVertical/index.tsx
+++ b/src/components/Table/TableVertical/index.tsx
@@ -43,7 +43,11 @@ const TableVertical: FC<ComponentProps> = ({altColors = false, className, innerB
     );
   };
 
-  return <table className={clsx('TableVertical', className)}>{renderBody()}</table>;
+  return (
+    <div className={clsx('TableVerticalWrapper', className)}>
+      <table className={clsx('TableVertical', className)}>{renderBody()}</table>
+    </div>
+  );
 };
 
 export default TableVertical;


### PR DESCRIPTION
The reason it gets scrolled horizontally is because of that table width.
I made it to become scrollable by auto in CSS, which I think is a better way.

![Result](http://g.recordit.co/oJCYQFH7wJ.gif)
