### PR TITLE
Added a word wrap mixin to fix horizontal page movement in Docs

### DIFF
--- a/src/components/Table/TableVertical/TableVertical.scss
+++ b/src/components/Table/TableVertical/TableVertical.scss
@@ -1,4 +1,4 @@
-@import '../../../styles/mixins';
+@import 'src/styles/mixins';
 
 .TableVertical {
   border: 1px solid #e6e6e6;
@@ -20,14 +20,16 @@
       white-space: nowrap;
     }
 
-    @media (max-width: 400px) {
+    &--border {
+      border: 1px solid #e6e6e6;
+    }
+  }
+
+  @media (max-width: 400px) {
+    &__td {
       &:last-child {
         @include word-wrap;
       }
-    }
-
-    &--border {
-      border: 1px solid #e6e6e6;
     }
   }
 }

--- a/src/components/Table/TableVertical/TableVertical.scss
+++ b/src/components/Table/TableVertical/TableVertical.scss
@@ -1,3 +1,4 @@
+@import '../../../styles/mixins';
 .TableVertical {
   border: 1px solid #e6e6e6;
   margin-bottom: 20px;
@@ -17,7 +18,11 @@
       padding-right: 16px;
       white-space: nowrap;
     }
-
+    @media (max-width: 400px) {
+      &:last-child {
+        @include word-wrap;
+      }
+    }
     &--border {
       border: 1px solid #e6e6e6;
     }

--- a/src/components/Table/TableVertical/TableVertical.scss
+++ b/src/components/Table/TableVertical/TableVertical.scss
@@ -1,4 +1,5 @@
 @import '../../../styles/mixins';
+
 .TableVertical {
   border: 1px solid #e6e6e6;
   margin-bottom: 20px;
@@ -18,11 +19,13 @@
       padding-right: 16px;
       white-space: nowrap;
     }
+
     @media (max-width: 400px) {
       &:last-child {
         @include word-wrap;
       }
     }
+
     &--border {
       border: 1px solid #e6e6e6;
     }

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -1,0 +1,11 @@
+@mixin word-wrap {
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  -ms-word-break: break-all;
+  word-break: break-all;
+  word-break: break-word;
+  -ms-hyphens: auto;
+  -moz-hyphens: auto;
+  -webkit-hyphens: auto;
+  hyphens: auto;
+}

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -1,11 +1,6 @@
 @mixin word-wrap {
-  overflow-wrap: break-word;
-  word-wrap: break-word;
-  -ms-word-break: break-all;
-  word-break: break-all;
-  word-break: break-word;
-  -ms-hyphens: auto;
-  -moz-hyphens: auto;
-  -webkit-hyphens: auto;
   hyphens: auto;
+  overflow-wrap: break-word;
+  word-break: break-word;
+  word-wrap: break-word;
 }

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -2,6 +2,6 @@
 @import 'colors';
 @import 'core';
 @import 'font';
+@import 'mixins';
 @import 'tables';
 @import 'toastify';
-@import 'mixins';

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -4,3 +4,4 @@
 @import 'font';
 @import 'tables';
 @import 'toastify';
+@import 'mixins';


### PR DESCRIPTION
This is the fix for the issue #220 

**Cause of the issue**
Since the table is not a fixed one, the padding applied to the td elements make the total table width go beyond for devices like iPhone SE. 

**Proposed Solution** 
We can break the words inside last element of td. I have done this for devices whose max-width is less than 400px using media query.
Since cross browser compatibility is preferable - I have referred to [Word Wrap Mixin](https://css-tricks.com/snippets/css/prevent-long-urls-from-breaking-out-of-container/) for the same.


![newBoston_Website_220_fix_video (1)](https://user-images.githubusercontent.com/29139815/94964672-bf7da000-0517-11eb-8d26-1e8cfac9f8d9.gif)

