### PR TITLE
276 - Add padding to last MenuGroup item on docs page

### DIFF
--- a/src/components/MenuGroup/MenuGroup.scss
+++ b/src/components/MenuGroup/MenuGroup.scss
@@ -3,9 +3,7 @@
   font-size: 16px;
 
   &:last-of-type {
-    .MenuGroup__toggle:not(.MenuGroup__toggle--expanded) {
-      padding-bottom: 10px;
-    }
+    padding-bottom: 32px;
   }
 
   &__submenu {

--- a/src/components/MenuGroup/MenuGroup.scss
+++ b/src/components/MenuGroup/MenuGroup.scss
@@ -3,7 +3,9 @@
   font-size: 16px;
 
   &:last-of-type {
-    padding-bottom: 32px;
+    .MenuGroup__toggle:not(.MenuGroup__toggle--expanded) {
+      padding-bottom: 10px;
+    }
   }
 
   &__submenu {

--- a/src/components/MenuGroup/MenuGroup.scss
+++ b/src/components/MenuGroup/MenuGroup.scss
@@ -1,9 +1,10 @@
 .MenuGroup {
+  $self: &;
   font-family: var(--font-family-inter-medium);
   font-size: 16px;
 
   &:last-of-type {
-    .MenuGroup__toggle:not(.MenuGroup__toggle--expanded) {
+    #{$self}__toggle:not(#{$self}__toggle--expanded) {
       padding-bottom: 10px;
     }
   }

--- a/src/components/MenuGroup/MenuGroup.scss
+++ b/src/components/MenuGroup/MenuGroup.scss
@@ -2,6 +2,12 @@
   font-family: var(--font-family-inter-medium);
   font-size: 16px;
 
+  &:last-of-type {
+    .MenuGroup__toggle:not(.MenuGroup__toggle--expanded) {
+      padding-bottom: 10px;
+    }
+  }
+
   &__submenu {
     display: none;
     flex-direction: column;


### PR DESCRIPTION
I added 10px padding to last item from menu only when that item is not expanded. 
- 10px was added to stay consistent with padding which is already defined on top first element of navigation.

I tried making SCSS more prettier but could not do much because of :last-of-type selector which was used - as there is no way to select last element with specific CSS class (If there is any better way to do this, please let me know)

After this change, there is a little bit more space under last item of navigation.

![Screenshot_15](https://user-images.githubusercontent.com/6311959/95016856-01146500-0656-11eb-8701-b8891c768635.png)
