### PR TITLE
295 - add extra margin for iphone x & 11

### DIFF
--- a/src/components/DashboardLayout/DashboardLayout.scss
+++ b/src/components/DashboardLayout/DashboardLayout.scss
@@ -17,7 +17,7 @@
   &__main-content {
     grid-column: 2 / span 1;
     overflow-y: auto;
-    padding-bottom: 96px;
+    padding-bottom: 120px;
   }
 
   @media (max-width: 768px) {


### PR DESCRIPTION
closes https://github.com/thenewboston-developers/Website/issues/295

For previous gen iphones, the margin looks fine, but for the buttonless iphones, it was hidden underneath the nav buttons. I've upped the padding-bottom, such that now it looks like this

![Screen Shot 2020-10-21 at 8 15 22 PM](https://user-images.githubusercontent.com/5943963/96820209-55e80780-13da-11eb-908b-47163263dc53.png)
