### PR TITLE
Utilize font-weight for Inter fonts

### DIFF
--- a/src/components/ContributorTasks/ContributorTasks.scss
+++ b/src/components/ContributorTasks/ContributorTasks.scss
@@ -68,11 +68,6 @@
     }
   }
 
-  &__task-title {
-    font-family: Inter;
-    font-weight: normal;
-  }
-
   @media (max-width: 1400px) {
     // Repository
     td:nth-child(2),

--- a/src/components/ContributorTasks/ContributorTasks.scss
+++ b/src/components/ContributorTasks/ContributorTasks.scss
@@ -69,7 +69,7 @@
   }
 
   &__task-title {
-    font-family: var(--font-family-inter);
+    font-family: Inter;
     font-weight: normal;
   }
 

--- a/src/components/DocWrapper/DocContainer/DocContainer.scss
+++ b/src/components/DocWrapper/DocContainer/DocContainer.scss
@@ -18,8 +18,8 @@
   }
 
   &__page-title {
-    font-weight: 300;
     font-size: 36px;
+    font-weight: 300;
     line-height: 1.2;
     margin-bottom: 24px;
 

--- a/src/components/DocWrapper/DocContainer/DocContainer.scss
+++ b/src/components/DocWrapper/DocContainer/DocContainer.scss
@@ -18,9 +18,9 @@
   }
 
   &__page-title {
-    font-family: var(--font-family-inter-light);
-    font-size: 36px;
+    font-family: Inter;
     font-weight: 300;
+    font-size: 36px;
     line-height: 1.2;
     margin-bottom: 24px;
 

--- a/src/components/DocWrapper/DocContainer/DocContainer.scss
+++ b/src/components/DocWrapper/DocContainer/DocContainer.scss
@@ -18,7 +18,6 @@
   }
 
   &__page-title {
-    font-family: Inter;
     font-weight: 300;
     font-size: 36px;
     line-height: 1.2;

--- a/src/components/EmptyPage/EmptyPage.scss
+++ b/src/components/EmptyPage/EmptyPage.scss
@@ -1,6 +1,7 @@
 .EmptyPage {
   display: flex;
-  font-family: var(--font-family-inter-light);
+  font-family: Inter;
+  font-weight: 300;
   justify-content: center;
   margin-top: 64px;
 }

--- a/src/components/EmptyPage/EmptyPage.scss
+++ b/src/components/EmptyPage/EmptyPage.scss
@@ -1,6 +1,5 @@
 .EmptyPage {
   display: flex;
-  font-family: Inter;
   font-weight: 300;
   justify-content: center;
   margin-top: 64px;

--- a/src/components/FlatNavLinks/FlatNavLinks.scss
+++ b/src/components/FlatNavLinks/FlatNavLinks.scss
@@ -6,7 +6,6 @@
     color: var(--color-sail-gray-400);
     cursor: pointer;
     display: flex;
-    font-family: Inter;
     font-weight: 700;
     height: 36px;
     outline: none;

--- a/src/components/FlatNavLinks/FlatNavLinks.scss
+++ b/src/components/FlatNavLinks/FlatNavLinks.scss
@@ -6,7 +6,8 @@
     color: var(--color-sail-gray-400);
     cursor: pointer;
     display: flex;
-    font-family: var(--font-family-inter-medium);
+    font-family: Inter;
+    font-weight: 700;
     height: 36px;
     outline: none;
     padding: 4px 0 4px 36px;

--- a/src/components/MenuGroup/MenuGroup.scss
+++ b/src/components/MenuGroup/MenuGroup.scss
@@ -1,6 +1,5 @@
 .MenuGroup {
   $self: &;
-  font-family: Inter;
   font-weight: 700;
 
   &:last-of-type {

--- a/src/components/MenuGroup/MenuGroup.scss
+++ b/src/components/MenuGroup/MenuGroup.scss
@@ -1,6 +1,7 @@
 .MenuGroup {
   $self: &;
-  font-family: var(--font-family-inter-medium);
+  font-family: Inter;
+  font-weight: 700;
 
   &:last-of-type {
     #{$self}__toggle:not(#{$self}__toggle--expanded) {

--- a/src/components/StepIndicator/StepIndicator.scss
+++ b/src/components/StepIndicator/StepIndicator.scss
@@ -1,8 +1,8 @@
 .StepIndicator {
   align-items: center;
   display: flex;
-  font-weight: 800;
   font-size: var(--font-size-medium);
+  font-weight: 800;
 
   &__bubble {
     align-items: center;

--- a/src/components/StepIndicator/StepIndicator.scss
+++ b/src/components/StepIndicator/StepIndicator.scss
@@ -1,9 +1,8 @@
 .StepIndicator {
   align-items: center;
   display: flex;
-  font-family: Inter;
   font-weight: 800;
-  font-size: 20px;
+  font-size: var(--font-size-medium);
 
   &__bubble {
     align-items: center;

--- a/src/components/StepIndicator/StepIndicator.scss
+++ b/src/components/StepIndicator/StepIndicator.scss
@@ -1,7 +1,8 @@
 .StepIndicator {
   align-items: center;
   display: flex;
-  font-family: var(--font-family-inter-bold);
+  font-family: Inter;
+  font-weight: 800;
   font-size: 20px;
 
   &__bubble {

--- a/src/components/TimeFilter/TimeFilter.scss
+++ b/src/components/TimeFilter/TimeFilter.scss
@@ -10,7 +10,6 @@
   &__option {
     color: var(--color-sail-gray-400);
     cursor: pointer;
-    font-family: Inter;
     font-weight: 700;
     margin-left: 12px;
 

--- a/src/components/TimeFilter/TimeFilter.scss
+++ b/src/components/TimeFilter/TimeFilter.scss
@@ -10,7 +10,8 @@
   &__option {
     color: var(--color-sail-gray-400);
     cursor: pointer;
-    font-family: var(--font-family-inter-medium);
+    font-family: Inter;
+    font-weight: 700;
     margin-left: 12px;
 
     &:focus {

--- a/src/components/Toast/Toast.scss
+++ b/src/components/Toast/Toast.scss
@@ -26,7 +26,7 @@
 
   &__text {
     color: var(--color-black);
-    font-family: var(--font-family-inter);
-    font-weight: bold;
+    font-family: Inter;
+    font-weight: 700;
   }
 }

--- a/src/components/Toast/Toast.scss
+++ b/src/components/Toast/Toast.scss
@@ -26,7 +26,6 @@
 
   &__text {
     color: var(--color-black);
-    font-family: Inter;
     font-weight: 700;
   }
 }

--- a/src/components/TopNav/TopNavDropdownMenuItem/TopNavDropdownMenuItem.scss
+++ b/src/components/TopNav/TopNavDropdownMenuItem/TopNavDropdownMenuItem.scss
@@ -2,7 +2,8 @@
 .TopNavDropdownMenuItem:visited {
   color: var(--color-sail-gray-400);
   display: block;
-  font-family: var(--font-family-inter-medium);
+  font-family: Inter;
+  font-weight: 700;
   padding: 6px 0;
   transition: color 0.1s ease;
 

--- a/src/components/TopNav/TopNavDropdownMenuItem/TopNavDropdownMenuItem.scss
+++ b/src/components/TopNav/TopNavDropdownMenuItem/TopNavDropdownMenuItem.scss
@@ -2,7 +2,6 @@
 .TopNavDropdownMenuItem:visited {
   color: var(--color-sail-gray-400);
   display: block;
-  font-family: Inter;
   font-weight: 700;
   padding: 6px 0;
   transition: color 0.1s ease;

--- a/src/components/TopNav/TopNavMenuItem/TopNavMenuItem.scss
+++ b/src/components/TopNav/TopNavMenuItem/TopNavMenuItem.scss
@@ -1,7 +1,6 @@
 .TopNavMenuItem,
 .TopNavMenuItem:visited {
   color: var(--color-sail-gray-400);
-  font-family: Inter;
   font-weight: 700;
   margin-right: 36px;
   transition: color 0.1s ease;

--- a/src/components/TopNav/TopNavMenuItem/TopNavMenuItem.scss
+++ b/src/components/TopNav/TopNavMenuItem/TopNavMenuItem.scss
@@ -1,7 +1,8 @@
 .TopNavMenuItem,
 .TopNavMenuItem:visited {
   color: var(--color-sail-gray-400);
-  font-family: var(--font-family-inter-medium);
+  font-family: Inter;
+  font-weight: 700;
   margin-right: 36px;
   transition: color 0.1s ease;
 

--- a/src/components/TotalAmount/TotalAmount.scss
+++ b/src/components/TotalAmount/TotalAmount.scss
@@ -3,8 +3,8 @@
 
   &__amount {
     color: var(--color-tertiary);
-    font-weight: 700;
     font-size: var(--font-size-medium);
+    font-weight: 700;
     margin-top: 8px;
   }
 

--- a/src/components/TotalAmount/TotalAmount.scss
+++ b/src/components/TotalAmount/TotalAmount.scss
@@ -3,7 +3,8 @@
 
   &__amount {
     color: var(--color-tertiary);
-    font-family: var(--font-family-inter-medium);
+    font-family: Inter;
+    font-weight: 700;
     font-size: var(--font-size-medium);
     margin-top: 8px;
   }

--- a/src/components/TotalAmount/TotalAmount.scss
+++ b/src/components/TotalAmount/TotalAmount.scss
@@ -3,7 +3,6 @@
 
   &__amount {
     color: var(--color-tertiary);
-    font-family: Inter;
     font-weight: 700;
     font-size: var(--font-size-medium);
     margin-top: 8px;

--- a/src/containers/Download/Download.scss
+++ b/src/containers/Download/Download.scss
@@ -51,7 +51,8 @@
         counter-increment: instruction;
         display: inline-flex;
         flex-shrink: 0;
-        font-family: var(--font-family-inter-bold);
+        font-family: Inter;
+        font-weight: 800;
         font-size: var(--font-size-medium);
         height: 36px;
         justify-content: center;
@@ -61,7 +62,8 @@
     }
 
     &__title {
-      font-family: var(--font-family-inter-bold);
+      font-family: Inter;
+      font-weight: 800;
       font-size: 20px;
       margin-bottom: 30px;
     }

--- a/src/containers/Download/Download.scss
+++ b/src/containers/Download/Download.scss
@@ -51,8 +51,8 @@
         counter-increment: instruction;
         display: inline-flex;
         flex-shrink: 0;
-        font-weight: 800;
         font-size: var(--font-size-medium);
+        font-weight: 800;
         height: 36px;
         justify-content: center;
         margin-right: 18px;
@@ -61,8 +61,8 @@
     }
 
     &__title {
-      font-weight: 800;
       font-size: 20px;
+      font-weight: 800;
       margin-bottom: 30px;
     }
   }

--- a/src/containers/Download/Download.scss
+++ b/src/containers/Download/Download.scss
@@ -51,7 +51,6 @@
         counter-increment: instruction;
         display: inline-flex;
         flex-shrink: 0;
-        font-family: Inter;
         font-weight: 800;
         font-size: var(--font-size-medium);
         height: 36px;
@@ -62,7 +61,6 @@
     }
 
     &__title {
-      font-family: Inter;
       font-weight: 800;
       font-size: 20px;
       margin-bottom: 30px;

--- a/src/containers/Help/Help.scss
+++ b/src/containers/Help/Help.scss
@@ -5,7 +5,8 @@
 
   &__a {
     display: block;
-    font-family: var(--font-family-inter-medium);
+    font-family: Inter;
+    font-weight: 700;
     margin-bottom: 6px;
   }
 

--- a/src/containers/Help/Help.scss
+++ b/src/containers/Help/Help.scss
@@ -5,7 +5,6 @@
 
   &__a {
     display: block;
-    font-family: Inter;
     font-weight: 700;
     margin-bottom: 6px;
   }

--- a/src/containers/Home/HomeComparisonCards/HomeComparisonCards.scss
+++ b/src/containers/Home/HomeComparisonCards/HomeComparisonCards.scss
@@ -39,7 +39,8 @@
     }
 
     &-value {
-      font-family: var(--font-family-inter-light);
+      font-family: Inter;
+      font-weight: 300;
       font-size: 36px;
     }
   }

--- a/src/containers/Home/HomeComparisonCards/HomeComparisonCards.scss
+++ b/src/containers/Home/HomeComparisonCards/HomeComparisonCards.scss
@@ -33,14 +33,14 @@
     margin-top: 60px;
 
     &-attribute {
-      font-size: 20px;
+      font-size: var(--font-size-medium);
       font-weight: 500;
       margin-top: 12px;
     }
 
     &-value {
-      font-weight: 300;
       font-size: 36px;
+      font-weight: 300;
     }
   }
 

--- a/src/containers/Home/HomeComparisonCards/HomeComparisonCards.scss
+++ b/src/containers/Home/HomeComparisonCards/HomeComparisonCards.scss
@@ -39,7 +39,6 @@
     }
 
     &-value {
-      font-family: Inter;
       font-weight: 300;
       font-size: 36px;
     }

--- a/src/containers/Home/HomeHero/HomeHero.scss
+++ b/src/containers/Home/HomeHero/HomeHero.scss
@@ -64,7 +64,6 @@
   }
 
   &__title {
-    font-family: Inter;
     font-weight: 300;
     font-size: 42px;
     line-height: 1.25;

--- a/src/containers/Home/HomeHero/HomeHero.scss
+++ b/src/containers/Home/HomeHero/HomeHero.scss
@@ -64,9 +64,9 @@
   }
 
   &__title {
-    font-family: var(--font-family-inter-light);
-    font-size: 42px;
+    font-family: Inter;
     font-weight: 300;
+    font-size: 42px;
     line-height: 1.25;
   }
 

--- a/src/containers/Home/HomeHero/HomeHero.scss
+++ b/src/containers/Home/HomeHero/HomeHero.scss
@@ -64,8 +64,8 @@
   }
 
   &__title {
-    font-weight: 300;
     font-size: 42px;
+    font-weight: 300;
     line-height: 1.25;
   }
 

--- a/src/containers/Leaderboard/LeaderboardContributor/LeaderboardContributor.scss
+++ b/src/containers/Leaderboard/LeaderboardContributor/LeaderboardContributor.scss
@@ -80,7 +80,8 @@
 
   &__user-login {
     display: block;
-    font-family: var(--font-family-inter-medium);
+    font-family: Inter;
+    font-weight: 700;
     font-size: 20px;
     line-height: 1.25;
     overflow: hidden;

--- a/src/containers/Leaderboard/LeaderboardContributor/LeaderboardContributor.scss
+++ b/src/containers/Leaderboard/LeaderboardContributor/LeaderboardContributor.scss
@@ -80,8 +80,8 @@
 
   &__user-login {
     display: block;
-    font-weight: 700;
     font-size: var(--font-size-medium);
+    font-weight: 700;
     line-height: 1.25;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/src/containers/Leaderboard/LeaderboardContributor/LeaderboardContributor.scss
+++ b/src/containers/Leaderboard/LeaderboardContributor/LeaderboardContributor.scss
@@ -80,9 +80,8 @@
 
   &__user-login {
     display: block;
-    font-family: Inter;
     font-weight: 700;
-    font-size: 20px;
+    font-size: var(--font-size-medium);
     line-height: 1.25;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/src/containers/Openings/OpeningDetails/OpeningDetails.scss
+++ b/src/containers/Openings/OpeningDetails/OpeningDetails.scss
@@ -48,7 +48,6 @@
   }
 
   &__list-label {
-    font-family: Inter;
     font-weight: 800;
     margin-top: 24px;
   }
@@ -60,7 +59,6 @@
 
   &__position {
     color: var(--color-primary);
-    font-family: Inter;
     font-weight: 300;
     font-size: 36px;
     line-height: 1.25;

--- a/src/containers/Openings/OpeningDetails/OpeningDetails.scss
+++ b/src/containers/Openings/OpeningDetails/OpeningDetails.scss
@@ -59,8 +59,8 @@
 
   &__position {
     color: var(--color-primary);
-    font-weight: 300;
     font-size: 36px;
+    font-weight: 300;
     line-height: 1.25;
     margin-top: 36px;
   }

--- a/src/containers/Openings/OpeningDetails/OpeningDetails.scss
+++ b/src/containers/Openings/OpeningDetails/OpeningDetails.scss
@@ -48,7 +48,8 @@
   }
 
   &__list-label {
-    font-family: var(--font-family-inter-bold);
+    font-family: Inter;
+    font-weight: 800;
     margin-top: 24px;
   }
 
@@ -59,7 +60,8 @@
 
   &__position {
     color: var(--color-primary);
-    font-family: var(--font-family-inter-light);
+    font-family: Inter;
+    font-weight: 300;
     font-size: 36px;
     line-height: 1.25;
     margin-top: 36px;

--- a/src/containers/Openings/Openings.scss
+++ b/src/containers/Openings/Openings.scss
@@ -25,7 +25,8 @@
   }
 
   &__opening-list-heading {
-    font-family: var(--font-family-inter-light);
+    font-family: Inter;
+    font-weight: 300;
     font-size: 36px;
     line-height: 1.25;
     margin: 16px 54px 36px;

--- a/src/containers/Openings/Openings.scss
+++ b/src/containers/Openings/Openings.scss
@@ -25,7 +25,6 @@
   }
 
   &__opening-list-heading {
-    font-family: Inter;
     font-weight: 300;
     font-size: 36px;
     line-height: 1.25;

--- a/src/containers/Openings/Openings.scss
+++ b/src/containers/Openings/Openings.scss
@@ -25,8 +25,8 @@
   }
 
   &__opening-list-heading {
-    font-weight: 300;
     font-size: 36px;
+    font-weight: 300;
     line-height: 1.25;
     margin: 16px 54px 36px;
   }

--- a/src/containers/Openings/OpeningsOpening/OpeningsOpening.scss
+++ b/src/containers/Openings/OpeningsOpening/OpeningsOpening.scss
@@ -19,8 +19,6 @@ $opening-card-box-shadow: 0 15px 40px 15px rgba(85, 108, 214, 0.18);
   }
 
   &__position {
-    color: var(--color-primary);
-    font-family: Inter;
     font-weight: 700;
     font-size: 18px;
   }

--- a/src/containers/Openings/OpeningsOpening/OpeningsOpening.scss
+++ b/src/containers/Openings/OpeningsOpening/OpeningsOpening.scss
@@ -20,7 +20,8 @@ $opening-card-box-shadow: 0 15px 40px 15px rgba(85, 108, 214, 0.18);
 
   &__position {
     color: var(--color-primary);
-    font-family: var(--font-family-inter-medium);
+    font-family: Inter;
+    font-weight: 700;
     font-size: 18px;
   }
 

--- a/src/containers/SlideUpAccountDetails/SlideUpAccountDetails.scss
+++ b/src/containers/SlideUpAccountDetails/SlideUpAccountDetails.scss
@@ -28,9 +28,8 @@
 
   &__user-login {
     display: block;
-    font-family: Inter;
     font-weight: 700;
-    font-size: 20px;
+    font-size: var(--font-size-medium);
     line-height: 1.25;
 
     &:hover {

--- a/src/containers/SlideUpAccountDetails/SlideUpAccountDetails.scss
+++ b/src/containers/SlideUpAccountDetails/SlideUpAccountDetails.scss
@@ -28,9 +28,9 @@
 
   &__user-login {
     display: block;
-    font-family: var(--font-family-inter-medium);
+    font-family: Inter;
+    font-weight: 700;
     font-size: 20px;
-    font-weight: 500;
     line-height: 1.25;
 
     &:hover {

--- a/src/containers/SlideUpAccountDetails/SlideUpAccountDetails.scss
+++ b/src/containers/SlideUpAccountDetails/SlideUpAccountDetails.scss
@@ -28,8 +28,8 @@
 
   &__user-login {
     display: block;
-    font-weight: 700;
     font-size: var(--font-size-medium);
+    font-weight: 700;
     line-height: 1.25;
 
     &:hover {

--- a/src/containers/Tasks/TasksTask/TasksTask.scss
+++ b/src/containers/Tasks/TasksTask/TasksTask.scss
@@ -57,8 +57,8 @@
   &__title {
     color: var(--color-primary);
     display: block;
-    font-weight: 700;
     font-size: 18px;
+    font-weight: 700;
 
     &:hover {
       color: var(--color-github-blue);

--- a/src/containers/Tasks/TasksTask/TasksTask.scss
+++ b/src/containers/Tasks/TasksTask/TasksTask.scss
@@ -57,9 +57,9 @@
   &__title {
     color: var(--color-primary);
     display: block;
-    font-family: var(--font-family-inter-medium);
+    font-family: Inter;
+    font-weight: 700;
     font-size: 18px;
-    font-weight: 600;
 
     &:hover {
       color: var(--color-github-blue);

--- a/src/containers/Tasks/TasksTask/TasksTask.scss
+++ b/src/containers/Tasks/TasksTask/TasksTask.scss
@@ -57,7 +57,6 @@
   &__title {
     color: var(--color-primary);
     display: block;
-    font-family: Inter;
     font-weight: 700;
     font-size: 18px;
 

--- a/src/styles/_core.scss
+++ b/src/styles/_core.scss
@@ -12,7 +12,7 @@ html {
 body {
   background: var(--color-bg);
   color: var(--color-primary);
-  font-family: Inter;
+  font-family: var(--font-family-default);
   font-weight: normal;
   font-size: var(--font-size-regular);
   line-height: 1.5;
@@ -21,7 +21,6 @@ body {
 
 b,
 strong {
-  font-family: Inter;
   font-weight: 800;
 }
 

--- a/src/styles/_core.scss
+++ b/src/styles/_core.scss
@@ -12,15 +12,17 @@ html {
 body {
   background: var(--color-bg);
   color: var(--color-primary);
-  font-family: var(--font-family-inter);
+  font-family: Inter;
+  font-weight: normal;
   font-size: var(--font-size-regular);
   line-height: 1.5;
   max-height: 100vh;
 }
 
-b {
-  font-family: var(--font-family-inter-bold);
-  font-weight: 700;
+b,
+strong {
+  font-family: Inter;
+  font-weight: 800;
 }
 
 h1,
@@ -46,8 +48,4 @@ ol,
 ul {
   margin: 0;
   padding-inline-start: 32px;
-}
-
-strong {
-  font-family: var(--font-family-inter-bold);
 }

--- a/src/styles/_core.scss
+++ b/src/styles/_core.scss
@@ -13,7 +13,6 @@ body {
   background: var(--color-bg);
   color: var(--color-primary);
   font-family: var(--font-family-default);
-  font-weight: normal;
   font-size: var(--font-size-regular);
   line-height: 1.5;
   max-height: 100vh;

--- a/src/styles/_font.scss
+++ b/src/styles/_font.scss
@@ -11,7 +11,7 @@
   src: url('./fonts/Inter/ttf/Inter-Regular.ttf') format('truetype'),
     url('./fonts/Inter/web/woff/Inter-Regular.woff') format('woff'),
     url('./fonts/Inter/web/woff2/Inter-Regular.woff2') format('woff2');
-  font-weight: 400; // normal
+  font-weight: 400;
 }
 
 @font-face {
@@ -19,7 +19,7 @@
   src: url('./fonts/Inter/ttf/Inter-Medium.ttf') format('truetype'),
     url('./fonts/Inter/web/woff/Inter-Medium.woff') format('woff'),
     url('./fonts/Inter/web/woff2/Inter-Medium.woff2') format('woff2');
-  font-weight: 700; // bold
+  font-weight: 700;
 }
 
 @font-face {
@@ -40,6 +40,7 @@
 @import url('https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;500;600;700&display=swap');
 
 :root {
+  --font-family-default: Inter, sans-serif;
   --font-family-mono-roboto: 'Roboto Mono', monospace;
   --font-family-mono: JetBrainsMono, monospace;
   --font-size-large: 24px;

--- a/src/styles/_font.scss
+++ b/src/styles/_font.scss
@@ -1,32 +1,4 @@
 @font-face {
-  font-family: InterBold;
-  src: url('./fonts/Inter/ttf/Inter-Bold.ttf') format('truetype'),
-    url('./fonts/Inter/web/woff/Inter-Bold.woff') format('woff'),
-    url('./fonts/Inter/web/woff2/Inter-Bold.woff2') format('woff2');
-}
-
-@font-face {
-  font-family: InterLight;
-  src: url('./fonts/Inter/ttf/Inter-Light.ttf') format('truetype'),
-    url('./fonts/Inter/web/woff/Inter-Light.woff') format('woff'),
-    url('./fonts/Inter/web/woff2/Inter-Light.woff2') format('woff2');
-}
-
-@font-face {
-  font-family: InterMedium;
-  src: url('./fonts/Inter/ttf/Inter-Medium.ttf') format('truetype'),
-    url('./fonts/Inter/web/woff/Inter-Medium.woff') format('woff'),
-    url('./fonts/Inter/web/woff2/Inter-Medium.woff2') format('woff2');
-}
-
-@font-face {
-  font-family: InterRegular;
-  src: url('./fonts/Inter/ttf/Inter-Regular.ttf') format('truetype'),
-    url('./fonts/Inter/web/woff/Inter-Regular.woff') format('woff'),
-    url('./fonts/Inter/web/woff2/Inter-Regular.woff2') format('woff2');
-}
-
-@font-face {
   font-family: Inter;
   src: url('./fonts/Inter/ttf/Inter-Light.ttf') format('truetype'),
     url('./fonts/Inter/web/woff/Inter-Light.woff') format('woff'),
@@ -39,7 +11,7 @@
   src: url('./fonts/Inter/ttf/Inter-Regular.ttf') format('truetype'),
     url('./fonts/Inter/web/woff/Inter-Regular.woff') format('woff'),
     url('./fonts/Inter/web/woff2/Inter-Regular.woff2') format('woff2');
-  font-weight: normal;
+  font-weight: 400; // normal
 }
 
 @font-face {
@@ -47,7 +19,7 @@
   src: url('./fonts/Inter/ttf/Inter-Medium.ttf') format('truetype'),
     url('./fonts/Inter/web/woff/Inter-Medium.woff') format('woff'),
     url('./fonts/Inter/web/woff2/Inter-Medium.woff2') format('woff2');
-  font-weight: bold;
+  font-weight: 700; // bold
 }
 
 @font-face {
@@ -68,10 +40,6 @@
 @import url('https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;500;600;700&display=swap');
 
 :root {
-  --font-family-inter-bold: InterBold, serif;
-  --font-family-inter-light: InterLight, sans-serif;
-  --font-family-inter-medium: InterMedium, sans-serif;
-  --font-family-inter: InterRegular, sans-serif;
   --font-family-mono-roboto: 'Roboto Mono', monospace;
   --font-family-mono: JetBrainsMono, monospace;
   --font-size-large: 24px;

--- a/src/styles/_font.scss
+++ b/src/styles/_font.scss
@@ -27,6 +27,38 @@
 }
 
 @font-face {
+  font-family: Inter;
+  src: url('./fonts/Inter/ttf/Inter-Light.ttf') format('truetype'),
+    url('./fonts/Inter/web/woff/Inter-Light.woff') format('woff'),
+    url('./fonts/Inter/web/woff2/Inter-Light.woff2') format('woff2');
+  font-weight: 300;
+}
+
+@font-face {
+  font-family: Inter;
+  src: url('./fonts/Inter/ttf/Inter-Regular.ttf') format('truetype'),
+    url('./fonts/Inter/web/woff/Inter-Regular.woff') format('woff'),
+    url('./fonts/Inter/web/woff2/Inter-Regular.woff2') format('woff2');
+  font-weight: normal;
+}
+
+@font-face {
+  font-family: Inter;
+  src: url('./fonts/Inter/ttf/Inter-Medium.ttf') format('truetype'),
+    url('./fonts/Inter/web/woff/Inter-Medium.woff') format('woff'),
+    url('./fonts/Inter/web/woff2/Inter-Medium.woff2') format('woff2');
+  font-weight: bold;
+}
+
+@font-face {
+  font-family: Inter;
+  src: url('./fonts/Inter/ttf/Inter-Bold.ttf') format('truetype'),
+    url('./fonts/Inter/web/woff/Inter-Bold.woff') format('woff'),
+    url('./fonts/Inter/web/woff2/Inter-Bold.woff2') format('woff2');
+  font-weight: 800;
+}
+
+@font-face {
   font-family: JetBrainsMono;
   src: url('./fonts/JetBrainsMono/web/woff2/JetBrainsMono-Regular.woff2') format('woff2'),
     url('./fonts/JetBrainsMono/web/woff/JetBrainsMono-Regular.woff') format('woff'),


### PR DESCRIPTION
Hey all, this is the fix for #293 - I implemented the strategy I mentioned there.

The mapping I created for [inter style weight class](https://github.com/rsms/inter#design) to CSS font-weight is as follows:

Inter Style -- CSS font-weight

light -- 300
regular -- normal (400)
medium -- bold (700)
bold -- 800


I tested a few usages and it works.  If it's what you're expecting, we can merge (no functional changes yet), I can help convert the existing font-family for the Inter fonts to use the Inter family and then properly utilize the new font-weight, so we can deprecate the current usage.

Oh, and here's my account number :)
3cdb51ef0b7da3db65f47c170ec1815f3409c9781d4d8ca6c976273a732c9218

Thanks!