### PR TITLE
Making spacing equal on download page

### DIFF
--- a/src/containers/Download/Download.scss
+++ b/src/containers/Download/Download.scss
@@ -13,7 +13,7 @@
   &__download-button {
     align-items: center;
     display: flex;
-    margin-bottom: 60px;
+    margin-bottom: 43px;
   }
 
   &__download-icon {


### PR DESCRIPTION
I have changed the margin so the space will be evenly match on top and bottom of the download button ,

Account : #5d608c2154b21be60d810b68c151005b05cf7cb3bec936693f06f7cbf1dcc7c3
