### PR TITLE
fix: Apply z-translation to make rotated chevron visible in Safari

### DIFF
--- a/src/components/TopNav/TopNavPopoverButton/TopNavPopoverButton.scss
+++ b/src/components/TopNav/TopNavPopoverButton/TopNavPopoverButton.scss
@@ -23,7 +23,7 @@
     transition: transform 0.3s ease-in-out;
 
     &--open {
-      transform: rotateX(180deg);
+      transform: rotateX(180deg) translateZ(-1px);
     }
   }
 


### PR DESCRIPTION
fixes thenewboston-developers/Website#446

Unfortunately explicitly setting `backface-visibility: visible` does nothing. Safari has some issues here.
The transition in Safari is not as smooth, but at least visible when toggling.

<hr>

```
cd9e5d25a39baa7ef490d9521cf56a5c9bc7350c095ad7c7c60e75b8575f72bc
```