### PR TITLE
#551 Fixed typo in Root Account File description in documentation

### DIFF
--- a/src/containers/Guide/GuideIntroduction/index.tsx
+++ b/src/containers/Guide/GuideIntroduction/index.tsx
@@ -29,7 +29,7 @@ const GuideIntroduction: FC = () => {
           'Often referred to as a "confirmation," a block that a validator signs as confirmation that it has been added to their blockchain; indicates that the transactions have been validated and that the coins have been successfully transferred',
         ],
         ['Blockchain', 'An ordered list of confirmation blocks'],
-        ['Root Account File', 'A historic record (snapshot) of all account balances at a given coin in time'],
+        ['Root Account File', 'A historic record (snapshot) of all account balances at a given point in time'],
       ]}
     />
   );


### PR DESCRIPTION
Fixed typo in Root Account File description in documentation by replacing "coin" with "point".

TCB Account Number:
f6e015e67563ae5d0bde71477e9d7b7a8a759fb252b50aa07720eba1caf9bbc3