### PR TITLE
fixed typo in root account file description

### DIFF
--- a/src/containers/Guide/GuideIntroduction/index.tsx
+++ b/src/containers/Guide/GuideIntroduction/index.tsx
@@ -29,7 +29,7 @@ const GuideIntroduction: FC = () => {
           'Often referred to as a "confirmation," a block that a validator signs as confirmation that it has been added to their blockchain; indicates that the transactions have been validated and that the coins have been successfully transferred',
         ],
         ['Blockchain', 'An ordered list of confirmation blocks'],
-        ['Root Account File', 'A historic record (snapshot) of all account balances at a given coin in time'],
+        ['Root Account File', 'A historic record (snapshot) of all account balances at a given point in time'],
       ]}
     />
   );


### PR DESCRIPTION
Fixed typo of "coin" in Root Account File description
Issue: #551 for 500 newboston sheckles
Account number: c1d8c531d0c0045a8cd7f78bfd1ea4ef03e66931dadda5e19bcb462875001038