### PR TITLE
typo fixes for coins and points

### DIFF
--- a/src/containers/Guide/GuideBanks/index.tsx
+++ b/src/containers/Guide/GuideBanks/index.tsx
@@ -62,7 +62,7 @@ const GuideBanks: FC = () => {
         account one by one.
       </p>
       <p>
-        <strong>Important Note:</strong> If and when a bank server goes down, the coins of all accounts using that bank
+        <strong>Important Note:</strong> If and when a bank server goes down, the point of all accounts using that bank
         will always remain secure. This is because unlike a real-world bank, network banks do not store coins. All
         account balances are maintained and updated by the primary validator. Both the root balance sheet and blockchain
         are continuously backed up by several confirmation validators, in the case where the primary validator goes

--- a/src/containers/Guide/GuideBanks/index.tsx
+++ b/src/containers/Guide/GuideBanks/index.tsx
@@ -62,7 +62,7 @@ const GuideBanks: FC = () => {
         account one by one.
       </p>
       <p>
-        <strong>Important Note:</strong> If and when a bank server goes down, the point of all accounts using that bank
+        <strong>Important Note:</strong> If and when a bank server goes down, the coins of all accounts using that bank
         will always remain secure. This is because unlike a real-world bank, network banks do not store coins. All
         account balances are maintained and updated by the primary validator. Both the root balance sheet and blockchain
         are continuously backed up by several confirmation validators, in the case where the primary validator goes

--- a/src/containers/Guide/GuideConfirmationValidators/index.tsx
+++ b/src/containers/Guide/GuideConfirmationValidators/index.tsx
@@ -20,7 +20,7 @@ const GuideConfirmationValidators: FC = () => {
       <DocList variant="ul">
         <li>Root account file</li>
         <ul>
-          <li>This is the flattened representation of all account balances at a given coin in time</li>
+          <li>This is the flattened representation of all account balances at a given point in time</li>
         </ul>
         <li>Root account file hash</li>
         <ul>

--- a/src/containers/Guide/GuideIntroduction/index.tsx
+++ b/src/containers/Guide/GuideIntroduction/index.tsx
@@ -29,7 +29,7 @@ const GuideIntroduction: FC = () => {
           'Often referred to as a "confirmation," a block that a validator signs as confirmation that it has been added to their blockchain; indicates that the transactions have been validated and that the coins have been successfully transferred',
         ],
         ['Blockchain', 'An ordered list of confirmation blocks'],
-        ['Root Account File', 'A historic record (snapshot) of all account balances at a given coin in time'],
+        ['Root Account File', 'A historic record (snapshot) of all account balances at a given point in time'],
       ]}
     />
   );

--- a/src/containers/Guide/GuideRootAccountFile/index.tsx
+++ b/src/containers/Guide/GuideRootAccountFile/index.tsx
@@ -8,8 +8,8 @@ const GuideRootAccountFile: FC = () => {
   return (
     <DocContainer className="GuideRootAccountFile" title="Root Account File">
       <p>
-        The root account file is a historic snapshot of all account balances at a given coin in time. Every validator in
-        the network, both primary and confirmation validators, generate and maintain their own root account file.
+        The root account file is a historic snapshot of all account balances at a given point in time. Every validator
+        in the network, both primary and confirmation validators, generate and maintain their own root account file.
         Different validators may have different account files depending on when the snapshot was taken (which is usually
         when the node first comes online). However, given the architecture of the blockchain, all other nodes in the
         network can download and verify all validator account files regardless of when the snapshot was taken.
@@ -82,7 +82,7 @@ const GuideRootAccountFile: FC = () => {
         Unfortunately, the bank has not updated its database in years and is only able to store up to two rows in the
         transaction table; it's a very primitive economy after all. The historical log of the first transaction is lost,
         and Bucky never wrote it down. However, since Bucky had already verified the first transaction and also made a
-        copy of the account file at that coin in time, he does not need to view the first transaction again to ensure
+        copy of the account file at that point in time, he does not need to view the first transaction again to ensure
         that the economy is still fair. In fact, even if Bucky did have a record of the first transaction, he would not
         use it because there is simply no use for it. If Bucky wants to verify the current account balances, the logic
         is simple.

--- a/src/containers/StyleGuide/StyleGuideCss/index.tsx
+++ b/src/containers/StyleGuide/StyleGuideCss/index.tsx
@@ -258,8 +258,8 @@ const LeftMenu: FC = () => {
       </DocSubSection>
       <DocSubSection id={StyleGuideCssNav.blocksElements} title="Blocks vs. Elements">
         <p>
-          One of the pain-point of <DocInlineCode>BEM</DocInlineCode> is the ambiguity of the distinction between Blocks
-          and Elements. In order to keep it simple, this is the rule we are going to follow:
+          One of the pain-points of <DocInlineCode>BEM</DocInlineCode> is the ambiguity of the distinction between
+          Blocks and Elements. In order to keep it simple, this is the rule we are going to follow:
         </p>
         <DocList variant="ul">
           <li>

--- a/src/containers/StyleGuide/StyleGuideCss/index.tsx
+++ b/src/containers/StyleGuide/StyleGuideCss/index.tsx
@@ -258,7 +258,7 @@ const LeftMenu: FC = () => {
       </DocSubSection>
       <DocSubSection id={StyleGuideCssNav.blocksElements} title="Blocks vs. Elements">
         <p>
-          One of the pain-coins of <DocInlineCode>BEM</DocInlineCode> is the ambiguity of the distinction between Blocks
+          One of the pain-point of <DocInlineCode>BEM</DocInlineCode> is the ambiguity of the distinction between Blocks
           and Elements. In order to keep it simple, this is the rule we are going to follow:
         </p>
         <DocList variant="ul">


### PR DESCRIPTION
Multiple occurences for **coin of** as well as **coin in** instead of **point of**  and **point in**  

 #551 