### PR TITLE
Update Mac download instructions to assist with open/security errors

### DIFF
--- a/src/containers/Download/index.tsx
+++ b/src/containers/Download/index.tsx
@@ -91,7 +91,13 @@ const Download: FC = () => {
             <span className="instruction-container__instruction">Drag and drop the app to the Applications folder</span>
           </div>
           <div className="instruction-container__li">
-            <span className="instruction-container__instruction">Open the app</span>
+            <span className="instruction-container__instruction">
+              Open the app. If you see an error because the Account Manager app is not from the App Store check out{' '}
+              <a href="https://support.apple.com/en-us/HT202491" target="_blank" rel="noreferrer">
+                these instructions
+              </a>{' '}
+              to allow the install.
+            </span>
           </div>
         </>
       );


### PR DESCRIPTION
**What**
Update instructions for installing the Mac Account Manager App to assist users in resolving the security warning regarding installing the an application that "cannot be verified".

**Why**
Users experience confusion and concern with security notifications from the MacOS. Addressing them increases trust in TNB.

**Note**, this is my first PR so just taking something small :) Could not see an issue raised on this yet.