### PR TITLE
[#679] Fix leaderboard drop down

### DIFF
--- a/src/containers/Leaderboard/index.tsx
+++ b/src/containers/Leaderboard/index.tsx
@@ -114,7 +114,6 @@ const Leaderboard = (): JSX.Element => {
   const renderNavLinks = (): ReactNode => {
     return (
       <FlatNavLinks<Repository>
-        className="Leaderboard__left-menu"
         handleOptionClick={handleNavOptionClick}
         options={REPOSITORY_FILTERS}
         selectedOption={repository}
@@ -139,7 +138,7 @@ const Leaderboard = (): JSX.Element => {
       <PageTitle title="Leaderboard" />
       <div className="Leaderboard">
         {renderTopSections()}
-        {renderNavLinks()}
+        <div className="Leaderboard__left-menu">{renderNavLinks()}</div>
         <div className="Leaderboard__contributor-list">{renderContributors()}</div>
       </div>
     </>


### PR DESCRIPTION
Fixes #679

The dropdown nav links are not appearing when screen size is less than 992px.

Currently the nav links in the leftMenu and the dropdown both share the same className `Leaderboard__left-menu`. The `Leaderboard__left-menu` className will be set to `display: none` when the screen size is less than 992px, which causes both nav links to disappear.

Placing the `Leaderboard__left-menu` className to be specific for the left menu nav links will solve the issue of the dropdown nav links not appearing.

Account Number: c54c04774efaae20746fd3f29cdd619fea512e119bc1082b863572b2e8844104
