### PR TITLE
Fixed a typo in Albanian language Hello World

### DIFF
--- a/src/containers/Home/HomeHero/hello-world.ts
+++ b/src/containers/Home/HomeHero/hello-world.ts
@@ -49,7 +49,7 @@ const HelloWorld: {[isoLangCode: string]: string} = {
   si: 'හෙලෝ ලෝකය',
   sk: 'Zdravo Svete',
   sl: 'Pozdravljen svet',
-  sq: 'Përshendetje Botë',
+  sq: 'Përshëndetje Botë',
   sr: 'Здраво свете',
   sv: 'Hej Värld',
   sw: 'Habari Dunia',


### PR DESCRIPTION
I fixed a typo in the Albanian language, it was same as what google translate shows but there is a typo so this is the correct one.

account number: dfddf07ec15cbf363ecb52eedd7133b70b3ec896b488460bcecaba63e8e36be5