### PR TITLE
Fix uneven space for social buttons on mobile

### DIFF
--- a/src/containers/Social/Social.scss
+++ b/src/containers/Social/Social.scss
@@ -30,6 +30,7 @@
     font-weight: 800;
     line-height: 1.25;
     margin: 0 auto 30px;
+    text-align: center;
   }
 
   &__subtext {

--- a/src/containers/Social/Social.scss
+++ b/src/containers/Social/Social.scss
@@ -7,7 +7,7 @@
   &__button-container {
     display: flex;
     flex-wrap: wrap;
-    justify-content: center;
+    justify-content: space-evenly;
     margin: auto;
     max-width: 600px;
   }
@@ -18,7 +18,6 @@
     box-shadow: 0 0 10px rgba(156, 156, 156, 0.3);
     height: 120px;
     margin-bottom: 12px;
-    margin-left: 12px;
     width: 180px;
 
     &__img {


### PR DESCRIPTION
The social buttons were not evenly spaced in mobile view, there was more space on the left than on the right. I tested the following solution using chrome tools and reproduced the desired behavior. 1. Removed margin-left from "&__doc-button, .MarketingButton" class , 2. Changed justify-content in "&__button-container " class from center to space-evenly.