### PR TITLE
Prevent content jumping in leaderboard page

### DIFF
--- a/src/containers/Leaderboard/LeaderboardContributor/LeaderboardContributor.scss
+++ b/src/containers/Leaderboard/LeaderboardContributor/LeaderboardContributor.scss
@@ -53,6 +53,7 @@
     border-radius: 50%;
     height: auto;
     max-width: 178px;
+    min-width: 178px;
   }
 
   &__user-avatar-container {
@@ -137,6 +138,7 @@
 
     &__user-avatar {
       max-width: 54px;
+      min-width: 54px;
     }
 
     &__user-avatar-rank {


### PR DESCRIPTION
Fixes #703 

Currently, the image content does not take up any width before loading, which makes the content that is on the right of the image to jump when it is loaded.

Adding min widths to the user avatars will prevent this from occurring.

Account Number: c54c04774efaae20746fd3f29cdd619fea512e119bc1082b863572b2e8844104