### PR TITLE
Fix Social page heading and links alignment

### DIFF
--- a/src/containers/Social/Social.scss
+++ b/src/containers/Social/Social.scss
@@ -1,4 +1,5 @@
 .Social {
+  align-items: center;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -8,8 +9,8 @@
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
-    margin: auto;
-    max-width: 600px;
+    margin: -6px;
+    max-width: 576px;
   }
 
   &__doc-button,
@@ -17,8 +18,7 @@
     border-radius: 12px;
     box-shadow: 0 0 10px rgba(156, 156, 156, 0.3);
     height: 120px;
-    margin-bottom: 12px;
-    margin-left: 12px;
+    margin: 6px;
     width: 180px;
 
     &__img {
@@ -30,14 +30,15 @@
     font-size: 36px;
     font-weight: 800;
     line-height: 1.25;
-    margin: 0 auto 30px;
+    margin-bottom: 30px;
+    text-align: center;
   }
 
   &__subtext {
     font-size: var(--font-size-regular);
     font-weight: 300;
     line-height: 1.5;
-    margin: 0 auto 60px;
+    margin-bottom: 60px;
     max-width: 425px;
     text-align: center;
   }


### PR DESCRIPTION
**Decription**
Fixes #686 alignment issues while keeping in line with the Figma design.
PS: No need to adjust font-size for mobile :)

**Additional context**
- No need for auto margins if the flex container has `align-items: center`.
- Links must use a negative container margin hack in order to not bleed their
margins when in smaller screen sizes.
- Max-width adjusted according to Figma, considering the negative margin hack.

**Preview**
![ezgif-7-041c5fca1ce5](https://user-images.githubusercontent.com/6797129/98737292-c4d6d180-2384-11eb-979c-14f08a4ba3aa.gif)

