### PR TITLE
Change buttons to Links in topnav popover to allow opening in new tab

### DIFF
--- a/src/components/TopNav/TopNavPopoverItem/index.tsx
+++ b/src/components/TopNav/TopNavPopoverItem/index.tsx
@@ -1,5 +1,5 @@
 import React, {FC} from 'react';
-import {useHistory} from 'react-router-dom';
+import {Link} from 'react-router-dom';
 
 import {Icon, IconType} from 'components';
 
@@ -15,21 +15,18 @@ interface ComponentProps {
 }
 
 const TopNavPopoverItem: FC<ComponentProps> = ({closePopover, description, iconSize, iconType, title, to}) => {
-  const history = useHistory();
-
   const handleButtonClick = (): void => {
-    history.push(to);
     closePopover();
   };
 
   return (
-    <button className="TopNavPopoverItem" onClick={handleButtonClick}>
+    <Link className="TopNavPopoverItem" to={to} onClick={handleButtonClick}>
       <Icon className="TopNavPopoverItem__icon" icon={iconType} size={iconSize} />
       <div className="TopNavPopoverItem__right">
         <span className="TopNavPopoverItem__title">{title}</span>
         <span className="TopNavPopoverItem__description">{description}</span>
       </div>
-    </button>
+    </Link>
   );
 };
 


### PR DESCRIPTION
This PR changes the buttons in TopNav to React Router Links. This allows opening the links in a new tab instead of being forced to open pages in the same tab.

The `closePopover` behavior is still maintained and called prior to opening the new link.

Fixes: https://github.com/thenewboston-developers/Website/issues/753