### PR TITLE
Change sorting of members to be based on contributorId

### DIFF
--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -65,9 +65,6 @@ export const getTeamMembers = (): TeamMember[] => {
   });
 
   return Object.entries(members)
-    .sort(
-      ([, a]: [string, any], [, b]: [string, any]) =>
-        new Date(b.createdDate).valueOf() - new Date(a.createdDate).valueOf(),
-    )
+    .sort(([, a]: [string, any], [, b]: [string, any]) => a.contributorId - b.contributorId)
     .map(([, member]) => member) as TeamMember[];
 };


### PR DESCRIPTION
Fixes #747 

The sorting of team members was based on created date previously, hence, new team members that are added on the the team will have a later date, which results the member to appear at the top of the list.

Let's change the sorting order to be based on the contributor id instead.

Example of order: (note that the contributor id is added for illustration purposes)
<img width="1429" alt="Screen Shot 2020-11-13 at 4 24 02 PM" src="https://user-images.githubusercontent.com/32864116/99046185-5a64a200-25cd-11eb-8c6a-3bda5650e2c3.png">

Acc No: c54c04774efaae20746fd3f29cdd619fea512e119bc1082b863572b2e8844104
