### PR TITLE
make contributions easier via fully automating the dev setup.

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,10 @@
+tasks:
+  - init: yarn install && yarn build
+    command: yarn start
+ports:
+  - port: 3000
+    onOpen: open-preview
+
+vscode:
+  extensions:
+    - esbenp.prettier-vscode@5.7.1:4Zx39KyQMoIz7x94PSmDmQ==

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <img alt="screenshot of website" src="https://imgur.com/Nw7W49v.png">
 </p>
 
-[![Website Status](https://img.shields.io/website?url=https%3A%2F%2Fthenewboston.com)](https://thenewboston.com) ![Activity](https://img.shields.io/github/commit-activity/m/thenewboston-developers/website) [![GitHub Issues](https://img.shields.io/github/issues/thenewboston-developers/website)](https://github.com/thenewboston-developers/website/issues) [![Contributors](https://img.shields.io/github/contributors/thenewboston-developers/website)](https://github.com/thenewboston-developers/Website/graphs/contributors) [![License](https://img.shields.io/github/license/thenewboston-developers/website)](http://opensource.org/licenses/MIT)
+[![Website Status](https://img.shields.io/website?url=https%3A%2F%2Fthenewboston.com)](https://thenewboston.com) ![Activity](https://img.shields.io/github/commit-activity/m/thenewboston-developers/website) [![GitHub Issues](https://img.shields.io/github/issues/thenewboston-developers/website)](https://github.com/thenewboston-developers/website/issues) [![Contributors](https://img.shields.io/github/contributors/thenewboston-developers/website)](https://github.com/thenewboston-developers/Website/graphs/contributors) [![License](https://img.shields.io/github/license/thenewboston-developers/website)](http://opensource.org/licenses/MIT) [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/from-referrer/)
 
 ## Table of Contents
 
@@ -46,6 +46,12 @@ Next steps:
 For further help, you can check out the [FAQs](https://thenewboston.com/faq).
 
 Finally, feel free to shoot any queries or suggestions. Don't hesitate. ;)
+
+### Online one click setup for contributing
+
+You can use Gitpod (an online IDE which is free for opensource) for working on issues and making PRs, with a single click it will launch a workspace and automatically: clone the repo, install the dependencies, run `yarn build` and finally `yarn start` to start the devserver.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
 
 Thanks to these amazing people:
 


### PR DESCRIPTION
Hi.

I work for Gitpod. This PR adds gitpod config to the repo to make contributions easier for newcomers i.e with a single click it will launch a workspace and automatically:

- clone the `Website` repo.
- install the dependencies.
- run `yarn build`.
- run `yarn start`

This can be helpful for beginners i.e they can start coding instantly without setting anything up.

You can give it a try on my fork of the repo via the following link:

https://gitpod.io/#https://github.com/nisarhassan12/Website-1

This is how it looks:

![image](https://user-images.githubusercontent.com/46004116/99100151-3c169a80-25fd-11eb-9c6d-34eaaa9437d9.png)



