### PR TITLE
👌auto select download tab based on user system

### DIFF
--- a/src/containers/Download/index.tsx
+++ b/src/containers/Download/index.tsx
@@ -14,15 +14,15 @@ enum Os {
 }
 
 const Download: FC = () => {
-  const UserOSMatcher = /Windows|Linux|Mac/gi.exec(navigator.userAgent);
-  let UserOS = 0;
+  const userOsMatcher = /Windows|Linux|Mac/gi.exec(navigator.userAgent);
+  let userOsTabIndex = 0;
 
-  if (UserOSMatcher && UserOSMatcher[0] === 'Mac') {
-    UserOS = 1;
+  if (userOsMatcher && userOsMatcher[0] === 'Mac') {
+    userOsTabIndex = 1;
   }
 
-  if (UserOSMatcher && UserOSMatcher[0] === 'Linux') {
-    UserOS = 2;
+  if (userOsMatcher && userOsMatcher[0] === 'Linux') {
+    userOsTabIndex = 2;
   }
 
   const [loading, setLoading] = useState<boolean>(true);
@@ -170,7 +170,7 @@ const Download: FC = () => {
           <Loader />
         ) : (
           <>
-            <Tabs defaultTab={UserOS} tabs={tabs} latestReleaseNumber={latestReleaseNumber} />
+            <Tabs defaultTab={userOsTabIndex} tabs={tabs} latestReleaseNumber={latestReleaseNumber} />
           </>
         )}
       </div>

--- a/src/containers/Download/index.tsx
+++ b/src/containers/Download/index.tsx
@@ -14,6 +14,17 @@ enum Os {
 }
 
 const Download: FC = () => {
+  const UserOSMatcher = /Windows|Linux|Mac/gi.exec(navigator.userAgent);
+  let UserOS = 0;
+
+  if (UserOSMatcher && UserOSMatcher[0] === 'Mac') {
+    UserOS = 1;
+  }
+
+  if (UserOSMatcher && UserOSMatcher[0] === 'Linux') {
+    UserOS = 2;
+  }
+
   const [loading, setLoading] = useState<boolean>(true);
   const [releases, setReleases] = useState<Release[]>([]);
 
@@ -159,7 +170,7 @@ const Download: FC = () => {
           <Loader />
         ) : (
           <>
-            <Tabs tabs={tabs} latestReleaseNumber={latestReleaseNumber} />
+            <Tabs defaultTab={UserOS} tabs={tabs} latestReleaseNumber={latestReleaseNumber} />
           </>
         )}
       </div>


### PR DESCRIPTION
## personal message
I loved the project, the website.
and because I learnt a lot from **Bucky Roberts** and **thenewboston** channel, I saw the download page and I was like, why the website doesn't know I use linux? so I did just that, small change but nice user experience, I just wanted to give a little thing back to Bucky and thenewboston cimmunity.

## PR details
when Download page loads, now the **Download** component try to guess user system to
calculate a `UserOS` number variable which represents the **index** of the
_tab_ that shows the OS specific download instruction
which is based on the index of each component in `tabs` array :

0. Windows
1. Mac
2. Linux

default is still _windows_ if the regex `/Windows|Linux|Mac/gi` doesn't mach anything in `navigator.userAgent`
thus closes #819 