### PR TITLE
Enforce width of task sections in leaderboard

### DIFF
--- a/src/components/ContributorTasks/ContributorTasks.scss
+++ b/src/components/ContributorTasks/ContributorTasks.scss
@@ -31,6 +31,7 @@
   // Recent Task (name of task)
   td:nth-child(1),
   th:nth-child(1) {
+    min-width: 140px;
     max-width: 140px;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -39,7 +40,8 @@
   // Repository
   td:nth-child(2),
   th:nth-child(2) {
-    width: 140px;
+    min-width: 140px;
+    max-width: 140px;
     overflow: hidden;
     text-overflow: ellipsis;
   }
@@ -47,13 +49,15 @@
   // Completed
   td:nth-child(3),
   th:nth-child(3) {
-    width: 70px;
+    min-width: 70px;
+    max-width: 70px;
   }
 
   // Amount
   td:nth-child(4),
   th:nth-child(4) {
-    width: 60px;
+    min-width: 100px;
+    max-width: 100px;
   }
 
   &__amount {

--- a/src/components/ContributorTasks/ContributorTasks.scss
+++ b/src/components/ContributorTasks/ContributorTasks.scss
@@ -31,8 +31,8 @@
   // Recent Task (name of task)
   td:nth-child(1),
   th:nth-child(1) {
-    min-width: 140px;
     max-width: 140px;
+    min-width: 140px;
     overflow: hidden;
     text-overflow: ellipsis;
   }
@@ -40,8 +40,8 @@
   // Repository
   td:nth-child(2),
   th:nth-child(2) {
-    min-width: 140px;
     max-width: 140px;
+    min-width: 140px;
     overflow: hidden;
     text-overflow: ellipsis;
   }
@@ -49,15 +49,15 @@
   // Completed
   td:nth-child(3),
   th:nth-child(3) {
-    min-width: 70px;
     max-width: 70px;
+    min-width: 70px;
   }
 
   // Amount
   td:nth-child(4),
   th:nth-child(4) {
-    min-width: 100px;
     max-width: 100px;
+    min-width: 100px;
   }
 
   &__amount {

--- a/src/components/ContributorTasks/index.tsx
+++ b/src/components/ContributorTasks/index.tsx
@@ -23,7 +23,9 @@ const ContributorTasks: FC<ComponentProps> = ({className, tasks}) => {
             {title}
           </A>
         </td>
-        <td className="ContributorTasks__repository">{repository}</td>
+        <td className="ContributorTasks__repository" title={repository}>
+          {repository}
+        </td>
         <td className="ContributorTasks__date-completed">{format(completed_date, 'L/d/yy')}</td>
         <td className="ContributorTasks__amount">+ {parseInt(amount_paid, 10).toLocaleString()}</td>
       </tr>


### PR DESCRIPTION
Fixes #839 

After enforcing the widths, added hover title:
- Long repository name:
<img width="1089" alt="Screen Shot 2020-11-15 at 5 53 48 PM" src="https://user-images.githubusercontent.com/32864116/99181924-7d798800-276c-11eb-98cf-1cedb30747ac.png">

- Short task name:
<img width="1103" alt="Screen Shot 2020-11-15 at 5 53 26 PM" src="https://user-images.githubusercontent.com/32864116/99181919-78b4d400-276c-11eb-97c9-4726f41a74cf.png">

- The width of the amount is set to be able to accommodate up to millions.
<img width="474" alt="Screen Shot 2020-11-15 at 5 57 17 PM" src="https://user-images.githubusercontent.com/32864116/99181929-89fde080-276c-11eb-8e0c-4ff1f94f3884.png">


Account Number:
c54c04774efaae20746fd3f29cdd619fea512e119bc1082b863572b2e8844104