### PR TITLE
[FAQ] Fix console error in development mode

### DIFF
--- a/src/containers/Faq/index.tsx
+++ b/src/containers/Faq/index.tsx
@@ -85,7 +85,7 @@ const Faq: FC = () => {
           {question}
           {id ? <HashLink className="Faq__HashLink" id={id} /> : null}
         </h2>
-        <p className="Faq__answer">{answer}</p>
+        <div className="Faq__answer">{answer}</div>
       </div>
     ));
   };


### PR DESCRIPTION
Fixes #845

Replacing a `<p>` tag with a `<div>` tag would remove the `validateDomNesting` console error.

Acc No: a9a75e0b86307696baff17022797d1fa3add4f63ef3528c8c3bbbfa60f4e5154