### PR TITLE
issue#909 - Long title words break the mobile design in the tasks page

### DIFF
--- a/src/containers/Tasks/TasksTask/TasksTask.scss
+++ b/src/containers/Tasks/TasksTask/TasksTask.scss
@@ -59,6 +59,7 @@
     display: block;
     font-size: 18px;
     font-weight: 700;
+    word-break: break-word;
 
     &:hover {
       color: var(--color-github-blue);

--- a/src/containers/Tasks/TasksTask/TasksTask.scss
+++ b/src/containers/Tasks/TasksTask/TasksTask.scss
@@ -1,3 +1,5 @@
+@import 'src/styles/mixins';
+
 .TasksTask {
   border-bottom: 1px solid var(--color-sail-gray-100);
   display: flex;
@@ -59,7 +61,7 @@
     display: block;
     font-size: 18px;
     font-weight: 700;
-    word-break: break-word;
+    @include word-wrap;
 
     &:hover {
       color: var(--color-github-blue);


### PR DESCRIPTION
Fixed #909 Added word-break so the design on mobile wont go out of view for the titles without spaces.

Old:
![image](https://user-images.githubusercontent.com/62712311/99677175-b3bf4c00-2a79-11eb-9225-d50c4e30c537.png)

New:
![image](https://user-images.githubusercontent.com/62712311/99677212-be79e100-2a79-11eb-8eef-ba90afd1242b.png)


acc nr:
cf59a784ff69e64e977359f28cd4d04c0aea7a37cf1b8bda3dfbde2364032855