### PR TITLE
Fix NaN reward

### DIFF
--- a/src/constants/regex.ts
+++ b/src/constants/regex.ts
@@ -1,0 +1,1 @@
+export const REGEX = {excludingNumber: /[^\d.]/g};

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 
 import {AMOUNT_COLOR, REPOSITORIES} from 'constants/github';
 import {BaseRelease, Issue, Release} from 'types/github';
+import {REGEX} from 'constants/regex';
 
 export const fetchGithubIssues = async (): Promise<Issue[]> => {
   const promises = REPOSITORIES.map((repoName) =>
@@ -17,7 +18,7 @@ export const fetchGithubIssues = async (): Promise<Issue[]> => {
     const amountLabels = issue.labels.filter(({color}: any) => color.toLowerCase() === AMOUNT_COLOR);
     return {
       ...issue,
-      amount: amountLabels.length ? parseInt(amountLabels[0].name.replace(/[^\d.]/g, ''), 10) : 0,
+      amount: amountLabels.length ? parseInt(amountLabels[0].name.replace(REGEX.excludingNumber, ''), 10) : 0,
       repositoryName: getRepositoryName(issue.repository_url),
     };
   });

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -17,7 +17,7 @@ export const fetchGithubIssues = async (): Promise<Issue[]> => {
     const amountLabels = issue.labels.filter(({color}: any) => color.toLowerCase() === AMOUNT_COLOR);
     return {
       ...issue,
-      amount: amountLabels.length ? parseInt(amountLabels[0].name, 10) : 0,
+      amount: amountLabels.length ? parseInt(amountLabels[0].name.replace(/[^\d.]/g, ''), 10) : 0,
       repositoryName: getRepositoryName(issue.repository_url),
     };
   });


### PR DESCRIPTION
Fixes #936

Currently, the value of the reward label is directly parsed out using `parseInt`. With the introduction of other words such as `PR Reward 5000`, parseInt will fail and return NaN.
This PR handles the NaN due to parseInt by extracting only the numerical value in reward label.

Fixed screenshot:
<img width="959" alt="Screen Shot 2020-11-20 at 10 13 36 PM" src="https://user-images.githubusercontent.com/32864116/99809707-a55a5880-2b7d-11eb-9672-3640cc7c1375.png">

Acc No: c54c04774efaae20746fd3f29cdd619fea512e119bc1082b863572b2e8844104