### PR TITLE
Fix double calls to onClick when clicked on Icons

### DIFF
--- a/src/components/Icon/index.tsx
+++ b/src/components/Icon/index.tsx
@@ -219,7 +219,7 @@ const Icon = forwardRef<HTMLDivElement, ComponentProps>(
           ...getCustomClassNames(className, '--disabled', disabled),
         })}
         ref={ref}
-        onClick={handleClick}
+        onClick={disabled ? noop : handleClick}
         onKeyDown={handleKeyDown}
         style={divStyle}
         tabIndex={tabIndex}

--- a/src/components/Icon/index.tsx
+++ b/src/components/Icon/index.tsx
@@ -102,7 +102,6 @@ interface ComponentProps {
 const Icon = forwardRef<HTMLDivElement, ComponentProps>(
   ({className, disabled = false, icon, onClick, onKeyDown, size, totalSize = 'unset', unfocusable = false}, ref) => {
     const iconProps = {
-      onClick: disabled ? noop : onClick,
       size,
     };
 

--- a/src/components/Icon/index.tsx
+++ b/src/components/Icon/index.tsx
@@ -2,7 +2,6 @@
 
 import React, {forwardRef, ReactNode, useMemo} from 'react';
 import clsx from 'clsx';
-import noop from 'lodash/noop';
 
 import AccountGroupIcon from 'mdi-react/AccountGroupIcon';
 import AlertCircleOutlineIcon from 'mdi-react/AlertCircleOutlineIcon';
@@ -219,7 +218,7 @@ const Icon = forwardRef<HTMLDivElement, ComponentProps>(
           ...getCustomClassNames(className, '--disabled', disabled),
         })}
         ref={ref}
-        onClick={disabled ? noop : handleClick}
+        onClick={handleClick}
         onKeyDown={handleKeyDown}
         style={divStyle}
         tabIndex={tabIndex}


### PR DESCRIPTION
Fixes #1014 

```
Currently, when clicking on the `Icon` components in our website, the 
onClick method of those Icons will be called twice.

As a result, the sorting order icon gets toggled twice at each click, not 
changing the order.

Let's remove the passing of onClick method to the icon itself, while leaving 
the responsibilities of onClick to the button that wraps around the icon.
```