### PR TITLE
Link leaderboard and task to profile page

### DIFF
--- a/src/containers/App.tsx
+++ b/src/containers/App.tsx
@@ -81,7 +81,7 @@ const App: FC = () => {
           <Route path="/project-proposals/:chapter?" component={ProjectProposals} />
           <Route path="/style-guide/:chapter?" component={StyleGuide} />
           <Route path="/user/signin/callback" component={Auth} />
-          <Route path="/user/profile" render={() => <Profile github_username="jamessspanggg" />} />
+          <Route path="/user/profile/:githubUsername" render={() => <Profile />} />
           <Redirect to="/" />
         </Switch>
       </Layout>

--- a/src/containers/Leaderboard/LeaderboardContributor/index.tsx
+++ b/src/containers/Leaderboard/LeaderboardContributor/index.tsx
@@ -66,7 +66,7 @@ const LeaderboardContributor: FC<ComponentProps> = ({
   const renderRight = () => (
     <div className="LeaderboardContributor__right">
       <div className="LeaderBoardContributor__user-container">
-        <A className="LeaderboardContributor__user-login" href={`https://github.com/${github_username}`}>
+        <A className="LeaderboardContributor__user-login" href={`/user/profile/${github_username}`}>
           {github_username}
         </A>
       </div>

--- a/src/containers/Profile/index.tsx
+++ b/src/containers/Profile/index.tsx
@@ -1,21 +1,20 @@
 import React, {FC} from 'react';
+import {useParams} from 'react-router-dom';
 
+import {ProfileUrlParams} from 'types/profiles';
 import ProfileInfo from './ProfileInfo';
 import TasksCompleted from './TasksCompleted';
 import './Profile.scss';
 
-interface ComponentProps {
-  github_username: string;
-}
-
-const Profile: FC<ComponentProps> = ({github_username}) => {
+const Profile: FC = () => {
+  const {githubUsername} = useParams<ProfileUrlParams>();
   return (
     <div className="Profile">
       <div className="Profile__left-section">
-        <ProfileInfo github_username={github_username} />
+        <ProfileInfo github_username={githubUsername} />
       </div>
       <div className="Profile__right-section">
-        <TasksCompleted github_username={github_username} />
+        <TasksCompleted github_username={githubUsername} />
       </div>
     </div>
   );

--- a/src/containers/Tasks/TasksTask/index.tsx
+++ b/src/containers/Tasks/TasksTask/index.tsx
@@ -33,7 +33,9 @@ const TasksTask: FC<ComponentProps> = ({
 
   const renderAssignees = () => {
     return assignedUsers.map(({avatar_url, login}) => (
-      <img alt={login} className="TasksTask__assignee" key={login} src={avatar_url} />
+      <A href={`/user/profile/${login}`}>
+        <img alt={login} className="TasksTask__assignee" key={login} src={avatar_url} />
+      </A>
     ));
   };
 

--- a/src/types/profiles.ts
+++ b/src/types/profiles.ts
@@ -1,0 +1,3 @@
+export interface ProfileUrlParams {
+  githubUsername: string;
+}


### PR DESCRIPTION
Fixes #1123 

Tasks page: Clicking on the profile image of the assignee will be directed to their corresponding profiles
Leaderboard page: Clicking on the username will be directed to their corresponding profiles