### PR TITLE
docs(confirmation validator): show account balance as number

### DIFF
--- a/src/containers/ConfirmationValidatorApi/ConfirmationValidatorApiAccounts/index.tsx
+++ b/src/containers/ConfirmationValidatorApi/ConfirmationValidatorApiAccounts/index.tsx
@@ -51,7 +51,7 @@ const ConfirmationValidatorApiAccounts: FC = () => {
       <DocEndpoint endpoint="/accounts/<account_number>/balance" method="GET" />
       <RequestResponseSnippet
         code={`{
-  "balance": "6"
+  "balance": 6
 }`}
         heading="Response"
       />


### PR DESCRIPTION
The confirmation validator docs on the [/accounts/<account_number>/balance](https://thenewboston.com/confirmation-validator-api/accounts#root:~:text=%7D-,GET%20%2Faccounts%2F%3Caccount_number%3E%2Fbalance,%7D) were wrong as they displayed the response `balance` key as a string instead of a number as shown in [this example request](http://157.230.75.212/accounts/6649dde16e1e56e27157d32fe37f7534d9f547436605fe44b550f5a7b9473035/balance).