### PR TITLE
Add validateField as callback during onChange

### DIFF
--- a/src/components/FormComponents/FormInput/index.tsx
+++ b/src/components/FormComponents/FormInput/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/jsx-props-no-spreading */
 
-import React, {FC} from 'react';
+import React, {ChangeEvent, FC} from 'react';
 import {Field} from 'formik';
 import clsx from 'clsx';
 
@@ -19,13 +19,20 @@ const FormInput: FC<ComponentProps> = ({
   ...baseInputProps
 }) => {
   const {className, name} = baseInputProps;
-  const {errors, touched} = useFormContext();
+  const {errors, handleChange, touched, validateField} = useFormContext();
   const error = !!errors[name] && !!touched[name];
+
+  const handleChangeAndValidate = (e: ChangeEvent) => {
+    handleChange(e);
+    setTimeout(() => {
+      validateField(name);
+    });
+  };
 
   return (
     <div className={clsx('FormInput FormFieldComponent', className)}>
       {renderFormLabel(name, className, label, required)}
-      <Field {...baseInputProps} as={Input} className="FormField" error={error} required={required} />
+      <Field {...baseInputProps} as={Input} className="FormField" error={error} onChange={handleChangeAndValidate} />
       {hideErrorBlock ? null : renderFormError(name, className, hideErrorText)}
     </div>
   );

--- a/src/containers/CreateAccount/index.tsx
+++ b/src/containers/CreateAccount/index.tsx
@@ -52,7 +52,10 @@ const CreateAccount: FC = () => {
   };
 
   const validationSchema = yup.object().shape({
-    confirmPassword: yup.string().oneOf([yup.ref('password'), ''], 'Passwords must match'),
+    confirmPassword: yup
+      .string()
+      .oneOf([yup.ref('password'), ''], 'Passwords must match')
+      .required(),
     email: yup.string().email().required('Email is required'),
     password: yup.string().required('Password is required'),
   });

--- a/src/hooks/useFormContext.tsx
+++ b/src/hooks/useFormContext.tsx
@@ -1,3 +1,4 @@
+import {ChangeEvent} from 'react';
 import {FormikErrors, FormikTouched, useFormikContext} from 'formik';
 
 interface Values {
@@ -6,22 +7,35 @@ interface Values {
 
 interface UseFormContextOutput<V> {
   errors: FormikErrors<Values>;
+  handleChange(e: ChangeEvent<any>): void;
   isValid: boolean;
   setFieldTouched(field: string, isTouched?: boolean, shouldValidate?: boolean): void;
   setFieldValue(field: string, value: any, shouldValidate?: boolean): void;
   touched: FormikTouched<Values>;
+  validateField(field: string): void;
   values: V;
 }
 
 function useFormContext<V = Values>(): UseFormContextOutput<V> {
-  const {errors, isValid, setFieldTouched, setFieldValue, touched, values} = useFormikContext<V>();
-
-  return {
+  const {
     errors,
+    handleChange,
     isValid,
     setFieldTouched,
     setFieldValue,
     touched,
+    validateField,
+    values,
+  } = useFormikContext<V>();
+
+  return {
+    errors,
+    handleChange,
+    isValid,
+    setFieldTouched,
+    setFieldValue,
+    touched,
+    validateField,
     values,
   };
 }


### PR DESCRIPTION
Fixes #1168 

From debugging the behaviour of formik on our website, it seems like the onChange events do not update the `errors` object as well as the `isValid` property. This causes the error messages to not update based on each input from the user, as well as the issue #1168.

This PR calls the `validateField` function to the onChange handler, which updates the `errors` object and `isValid` property every time the `onChange` event is fired.

Note: I'm not too familiar with Formik and unsure if this is the best and most elegant solution.

Acc No: c54c04774efaae20746fd3f29cdd619fea512e119bc1082b863572b2e8844104