### PR TITLE
Fix duplicate team socials 

### DIFF
--- a/src/containers/Teams/TeamOverview/index.tsx
+++ b/src/containers/Teams/TeamOverview/index.tsx
@@ -18,7 +18,7 @@ const TeamOverview: FC<ComponentProps> = ({teamFilter}) => {
         <h4 className="TeamOverview__sub-heading"> About the team </h4>
         <p className="TeamOverview__description">{description}</p>
         {platforms.map(({name, label, link}) => (
-          <div className="TeamOverview__social" key={label}>
+          <div className="TeamOverview__social" key={`${name}-${label}`}>
             <Icon
               className="TeamOverview__social-icon"
               icon={name === 'github' ? IconType.github : IconType.slack}


### PR DESCRIPTION
Fixes #1174 

There are duplicate team socials due to non-unique keys within the socials section in the TeamOverview. Providing unique keys within a map will ensure that React will render the items correctly without duplication. 