### PR TITLE
1373 - add tests for SlideUp component

### DIFF
--- a/src/components/SlideUp/SlideUp.test.tsx
+++ b/src/components/SlideUp/SlideUp.test.tsx
@@ -17,12 +17,13 @@ describe('SlideUp component', () => {
   test('calls close prop when component is clicked', () => {
     const close = jest.fn();
     render(<SlideUp close={close}>Hello World</SlideUp>);
-    fireEvent.click(screen.getByTestId('SlideUp'));
-    expect(close).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByTestId('SlideUp__overlay'));
+    expect(close).toHaveBeenCalled();
   });
 
   test('renders with className passed in', () => {
     render(<SlideUp close={() => {}} className="test" />);
-    expect(screen.getByTestId('SlideUpContent')).toHaveClass('test__content');
+    expect(screen.getByTestId('SlideUp')).toHaveClass('test');
+    expect(screen.getByTestId('SlideUp__content')).toHaveClass('test__content');
   });
 });

--- a/src/components/SlideUp/SlideUp.test.tsx
+++ b/src/components/SlideUp/SlideUp.test.tsx
@@ -16,8 +16,13 @@ describe('SlideUp component', () => {
 
   test('calls close prop when component is clicked', () => {
     const close = jest.fn();
-    const {getByRole} = render(<SlideUp close={close}>Hello World</SlideUp>);
-    fireEvent.click(getByRole(/button/));
+    render(<SlideUp close={close}>Hello World</SlideUp>);
+    fireEvent.click(screen.getByTestId('SlideUp'));
     expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  test('renders with className passed in', () => {
+    render(<SlideUp close={() => {}} className="test" />);
+    expect(screen.getByTestId('SlideUpContent')).toHaveClass('test__content');
   });
 });

--- a/src/components/SlideUp/SlideUp.test.tsx
+++ b/src/components/SlideUp/SlideUp.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {render, fireEvent} from '@testing-library/react';
+import {fireEvent, render, screen} from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
 import SlideUp from './index';
@@ -10,13 +10,12 @@ document.body.appendChild(slideUpRoot);
 
 describe('SlideUp component', () => {
   test('renders with text passed in', () => {
-    const {getByText} = render(<SlideUp close={() => {}}>Hello World</SlideUp>);
-
-    expect(getByText('Hello World')).toBeTruthy();
+    render(<SlideUp close={() => {}}>Hello World</SlideUp>);
+    expect(screen.getByText('Hello World')).toBeTruthy();
   });
 
   test('calls close prop when component is clicked', () => {
-    const close = jest.fn(() => {});
+    const close = jest.fn();
     const {getByRole} = render(<SlideUp close={close}>Hello World</SlideUp>);
     fireEvent.click(getByRole(/button/));
     expect(close).toHaveBeenCalledTimes(1);

--- a/src/components/SlideUp/SlideUp.test.tsx
+++ b/src/components/SlideUp/SlideUp.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import {render, fireEvent} from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+import SlideUp from './index';
+
+const slideUpRoot = document.createElement('div');
+slideUpRoot.setAttribute('id', 'slide-up-root');
+document.body.appendChild(slideUpRoot);
+
+describe('SlideUp component', () => {
+  test('renders with text passed in', () => {
+    const {getByText} = render(<SlideUp close={() => {}}>Hello World</SlideUp>);
+
+    expect(getByText('Hello World')).toBeTruthy();
+  });
+
+  test('calls close prop when component is clicked', () => {
+    const close = jest.fn(() => {});
+    const {getByRole} = render(<SlideUp close={close}>Hello World</SlideUp>);
+    fireEvent.click(getByRole(/button/));
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/SlideUp/index.tsx
+++ b/src/components/SlideUp/index.tsx
@@ -13,9 +13,11 @@ interface ComponentProps {
 const SlideUp: FC<ComponentProps> = ({children, className, close}) => {
   return createPortal(
     <>
-      <div className="SlideUp__overlay" onClick={close} role="button" tabIndex={0} />
+      <div className="SlideUp__overlay" onClick={close} role="button" tabIndex={0} data-testid="SlideUp" />
       <div className={clsx('SlideUp', className)}>
-        <div className={clsx('SlideUp__content', {...bemify(className, '__content')})}>{children}</div>
+        <div className={clsx('SlideUp__content', {...bemify(className, '__content')})} data-testid="SlideUpContent">
+          {children}
+        </div>
       </div>
     </>,
     document.getElementById('slide-up-root')!,

--- a/src/components/SlideUp/index.tsx
+++ b/src/components/SlideUp/index.tsx
@@ -13,9 +13,9 @@ interface ComponentProps {
 const SlideUp: FC<ComponentProps> = ({children, className, close}) => {
   return createPortal(
     <>
-      <div className="SlideUp__overlay" onClick={close} role="button" tabIndex={0} data-testid="SlideUp" />
-      <div className={clsx('SlideUp', className)}>
-        <div className={clsx('SlideUp__content', {...bemify(className, '__content')})} data-testid="SlideUpContent">
+      <div className="SlideUp__overlay" onClick={close} role="button" tabIndex={0} data-testid="SlideUp__overlay" />
+      <div className={clsx('SlideUp', className)} data-testid="SlideUp">
+        <div className={clsx('SlideUp__content', {...bemify(className, '__content')})} data-testid="SlideUp__content">
           {children}
         </div>
       </div>


### PR DESCRIPTION
closes #1373 

![image](https://user-images.githubusercontent.com/967811/108616564-5e7a3a00-73dc-11eb-94ee-4dde08c5a521.png)

![image](https://user-images.githubusercontent.com/967811/108616587-9f724e80-73dc-11eb-805f-64edd59b47a7.png)


The three lines at the beginning of the test file setting up the div#slide-up-root element are copied from [the docs](https://testing-library.com/docs/example-react-modal/) (changing the div's ID)