### PR TITLE
Add github actions test workflow

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,0 +1,43 @@
+name: Test
+on:
+  push:
+  pull_request:
+    branches:
+      - development
+jobs:
+  build:
+    name: Running test on Node ${{ matrix.node }} and ${{ matrix.os }}
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        node: ['12.x', '14.x']
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Use Node ${{ matrix.node }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Install dependencies
+        run: yarn install --network-timeout 1000000
+
+      - name: Test
+        run: yarn test --ci --coverage --maxWorkers=2

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,9 +1,9 @@
 name: Test
 on:
   push:
+    branches: [master, development]
   pull_request:
-    branches:
-      - development
+    branches: [development]
 jobs:
   build:
     name: Running test on Node ${{ matrix.node }} and ${{ matrix.os }}


### PR DESCRIPTION
Fixes part of https://github.com/thenewboston-developers/DevOps/issues/6

Seems like https://github.com/thenewboston-developers/Website/pull/1294 is abandoned and there were errors. It would be good to set this up now as there will be more PRs coming in to create tests. Adding test to the CI pipeline will save effort from reviewers to ensure tests have no failure.

Things to note:
- I'm only running the tests for node v12 and v14, I believe it's unnecessary to run node v10 and adding that will just take up more processing time for github actions (note that there are [usage limits](https://docs.github.com/en/actions/reference/usage-limits-billing-and-administration) to github actions). 
  - We can perhaps only run on one node version, which we can specify in the `README` file. This is so that CI runs faster and less prone to failures due to a lot of PRs trying to run github workflows at the same time.
- Currently the workflow will only execute when:
  -  it's a PR to the development branch, as well as pushes to the PR
  - any direct pushes to the team's repo

References:
- https://github.com/yarnpkg/yarn/issues/4890 (why i added the network timeout in `yarn install --network-timeout 1000000`)