### PR TITLE
ADD: Test for SocialMediaIcon;

### DIFF
--- a/src/components/SocialMediaIcon/SocialMediaIcon.test.tsx
+++ b/src/components/SocialMediaIcon/SocialMediaIcon.test.tsx
@@ -22,4 +22,13 @@ describe('SocialMediaIcon component', () => {
     expect(svgIcon?.getAttribute('width')).toEqual(SIZE.toString());
     expect(svgIcon?.getAttribute('height')).toEqual(SIZE.toString());
   });
+
+  test('renders socialMediaIcon and get by className', () => {
+    render(<SocialMediaIcon iconSize={SIZE} website={SocialMedia.facebook} />);
+
+    const el = screen.getByTestId('A');
+    expect(el.className).toContain('SocialMediaIcon');
+    expect(el.hasAttribute('href')).toBeTruthy();
+    expect(el.getAttribute('href')).toEqual(socialMediaUrls[SocialMedia.facebook]);
+  });
 });

--- a/src/components/SocialMediaIcon/SocialMediaIcon.test.tsx
+++ b/src/components/SocialMediaIcon/SocialMediaIcon.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import {render, screen} from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+import {SocialMedia} from 'types/social-media';
+import {socialMediaUrls} from 'utils/social-media';
+
+import SocialMediaIcon from './index';
+
+const SIZE = 16;
+
+describe('SocialMediaIcon component', () => {
+  test('renders with expected props of iconSize 16 and discord as website', () => {
+    render(<SocialMediaIcon iconSize={SIZE} website={SocialMedia.discord} />);
+
+    const el = screen.getByTestId('A');
+    expect(el).toBeTruthy();
+    expect(el.hasAttribute('href')).toBeTruthy();
+    expect(el.getAttribute('href')).toEqual(socialMediaUrls[SocialMedia.discord]);
+
+    const svgIcon = el.querySelector('.mdi-icon');
+    expect(svgIcon?.getAttribute('width')).toEqual(SIZE.toString());
+    expect(svgIcon?.getAttribute('height')).toEqual(SIZE.toString());
+  });
+});

--- a/src/components/SocialMediaIcon/SocialMediaIcon.test.tsx
+++ b/src/components/SocialMediaIcon/SocialMediaIcon.test.tsx
@@ -10,25 +10,34 @@ import SocialMediaIcon from './index';
 const SIZE = 16;
 
 describe('SocialMediaIcon component', () => {
-  test('renders with expected props of iconSize 16 and discord as website', () => {
+  test('renders with expected link', () => {
     render(<SocialMediaIcon iconSize={SIZE} website={SocialMedia.discord} />);
-
     const el = screen.getByTestId('A');
-    expect(el).toBeTruthy();
-    expect(el.hasAttribute('href')).toBeTruthy();
-    expect(el.getAttribute('href')).toEqual(socialMediaUrls[SocialMedia.discord]);
 
+    expect(el).toBeTruthy();
+    expect(el.getAttribute('href')).toEqual(socialMediaUrls[SocialMedia.discord]);
+  });
+
+  test('renders with correct iconSize', () => {
+    render(<SocialMediaIcon iconSize={SIZE} website={SocialMedia.facebook} />);
+    const el = screen.getByTestId('A');
     const svgIcon = el.querySelector('.mdi-icon');
+
     expect(svgIcon?.getAttribute('width')).toEqual(SIZE.toString());
     expect(svgIcon?.getAttribute('height')).toEqual(SIZE.toString());
   });
 
-  test('renders socialMediaIcon and get by className', () => {
+  test('renders with default className', () => {
     render(<SocialMediaIcon iconSize={SIZE} website={SocialMedia.facebook} />);
-
     const el = screen.getByTestId('A');
+
     expect(el.className).toContain('SocialMediaIcon');
-    expect(el.hasAttribute('href')).toBeTruthy();
-    expect(el.getAttribute('href')).toEqual(socialMediaUrls[SocialMedia.facebook]);
+  });
+
+  test('renders with className passed in', () => {
+    render(<SocialMediaIcon className="test-class" iconSize={SIZE} website={SocialMedia.facebook} />);
+    const el = screen.getByTestId('A');
+
+    expect(el.className).toContain('test-class');
   });
 });


### PR DESCRIPTION
Resolves: https://github.com/thenewboston-developers/Website/issues/1374

I've purposefully left out the test case where website is null. 
(as typescript will lint against this since it's not a valid enum in `SocialMedia`).

I've also included get by classname as well - Thx

Acc: baa336bca22c7590256a86c002e4dbe6c1f1c1f6c0a0fd3f0681eecb2cad0787