### PR TITLE
top nav mobile update

### DIFF
--- a/src/components/Layout/Layout.scss
+++ b/src/components/Layout/Layout.scss
@@ -10,8 +10,7 @@ $footer-height: 348px;
   }
 
   &__content,
-  &__Footer,
-  &__TopNav {
+  &__Footer {
     @media (min-width: 1366px) {
       margin-left: auto;
       margin-right: auto;
@@ -29,8 +28,6 @@ $footer-height: 348px;
   }
 
   &__top-nav-wrapper {
-    backdrop-filter: saturate(180%) blur(20px);
-    background: rgba(255, 255, 255, 0.8);
     position: sticky;
     top: 0;
     z-index: 1;

--- a/src/containers/TopNav/TopNav.scss
+++ b/src/containers/TopNav/TopNav.scss
@@ -2,11 +2,28 @@ $dropdown-height: 316px;
 $mobile-dropdown-height: 1000px;
 $top-nav-height: 60px;
 
+@keyframes transitionBackground {
+  from {
+    backdrop-filter: saturate(180%) blur(20px);
+    background: rgba(255, 255, 255, 0.8);
+  }
+  to {
+    backdrop-filter: unset;
+    background: var(--color-white);
+  }
+}
+
 .TopNav {
   align-items: center;
   display: flex;
   height: $top-nav-height;
   justify-content: space-between;
+
+  @media (min-width: 1366px) {
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 1366px;
+  }
 
   &__left {
     align-items: center;
@@ -20,5 +37,14 @@ $top-nav-height: 60px;
   &__right {
     align-items: center;
     display: flex;
+  }
+
+  &__wrapper {
+    backdrop-filter: saturate(180%) blur(20px);
+    background: rgba(255, 255, 255, 0.8);
+
+    &--mobile-menu-open {
+      animation: transitionBackground 0.3s forwards;
+    }
   }
 }

--- a/src/containers/TopNav/TopNavMobileMenu/TopNavMobileMenu.scss
+++ b/src/containers/TopNav/TopNavMobileMenu/TopNavMobileMenu.scss
@@ -13,18 +13,22 @@ $top-nav-height: 60px;
 
 @keyframes mobileSlideDown {
   from {
+    opacity: 0;
     top: $top-nav-height - $mobile-dropdown-height;
   }
   to {
+    opacity: 1;
     top: $top-nav-height;
   }
 }
 
 @keyframes slideDown {
   from {
+    opacity: 0;
     top: $top-nav-height - $dropdown-height;
   }
   to {
+    opacity: 1;
     top: $top-nav-height;
   }
 }
@@ -33,7 +37,6 @@ $top-nav-height: 60px;
   display: none;
 
   @media (max-width: 1200px) {
-    background-color: var(--color-bg);
     display: block;
   }
 
@@ -85,10 +88,13 @@ $top-nav-height: 60px;
   &__column-title {
     background-color: transparent;
     border: 0;
-    color: var(--color-sail-gray-300);
     cursor: pointer;
     outline: none;
     padding: 0;
+
+    &--accordion {
+      color: var(--color-sail-gray-400);
+    }
   }
 
   &__dropdown-container {

--- a/src/containers/TopNav/TopNavMobileMenu/TopNavMobileMenu.scss
+++ b/src/containers/TopNav/TopNavMobileMenu/TopNavMobileMenu.scss
@@ -60,8 +60,10 @@ $top-nav-height: 60px;
     width: $top-nav-height;
     z-index: 3;
 
-    &:hover {
-      background: rgba(0, 0, 0, 0.1);
+    @media (hover: hover) and (pointer: fine) {
+      &:hover {
+        background: rgba(0, 0, 0, 0.1);
+      }
     }
   }
 

--- a/src/containers/TopNav/TopNavMobileMenu/index.tsx
+++ b/src/containers/TopNav/TopNavMobileMenu/index.tsx
@@ -1,29 +1,23 @@
-import React, {ReactNode, useEffect, useState} from 'react';
+import React, {FC, ReactNode, useState} from 'react';
 import {useSelector} from 'react-redux';
-import {Link, useLocation} from 'react-router-dom';
+import {Link} from 'react-router-dom';
 import clsx from 'clsx';
 
 import {A, Icon, IconType} from 'components';
-import {useBooleanState, useWindowDimensions} from 'hooks';
 import {selectActiveUser} from 'selectors/state';
 import './TopNavMobileMenu.scss';
+import {createPortal} from 'react-dom';
 
-const TopNavMobileMenu = () => {
+interface ComponentProps {
+  closeMenu(): void;
+  menuOpen: boolean;
+  smallDevice: boolean;
+  toggleMenu(): void;
+}
+
+const TopNavMobileMenu: FC<ComponentProps> = ({closeMenu, menuOpen, smallDevice, toggleMenu}) => {
   const activeUser = useSelector(selectActiveUser);
-  const [menuOpen, toggleMenu, , closeMenu] = useBooleanState(false);
   const [openSection, setOpenSection] = useState<'community' | 'getStarted' | 'more' | 'other' | null>(null);
-  const [smallDevice, setSmallDevice] = useState(false);
-  const {pathname} = useLocation();
-  const {width} = useWindowDimensions();
-
-  useEffect(() => {
-    closeMenu();
-  }, [closeMenu, pathname]);
-
-  useEffect(() => {
-    if (width > 1200) closeMenu();
-    setSmallDevice(width < 992);
-  }, [closeMenu, menuOpen, width]);
 
   const handleColumnTitleClick = (section: 'community' | 'getStarted' | 'more' | 'other') => (): void => {
     if (!smallDevice) return;
@@ -38,7 +32,7 @@ const TopNavMobileMenu = () => {
     return (
       <div className="TopNavMobileMenu__column">
         <button className="TopNavMobileMenu__title-wrapper" onClick={handleColumnTitleClick(section)}>
-          <span className="TopNavMobileMenu__column-title">{title}</span>
+          <span className="TopNavMobileMenu__column-title TopNavMobileMenu__column-title--accordion">{title}</span>
           {smallDevice && (
             <span className="TopNavMobileMenu__icon-holder">
               <Icon
@@ -161,7 +155,7 @@ const TopNavMobileMenu = () => {
       <button className="TopNavMobileMenu__button" onClick={toggleMenu}>
         <Icon icon={IconType.menu} size={24} />
       </button>
-      {menuOpen && renderMenu()}
+      {menuOpen && createPortal(renderMenu(), document.getElementById('popover-root')!)}
     </div>
   );
 };

--- a/src/containers/TopNav/TopNavMobileMenu/index.tsx
+++ b/src/containers/TopNav/TopNavMobileMenu/index.tsx
@@ -6,7 +6,6 @@ import clsx from 'clsx';
 import {A, Icon, IconType} from 'components';
 import {selectActiveUser} from 'selectors/state';
 import './TopNavMobileMenu.scss';
-import {createPortal} from 'react-dom';
 
 interface ComponentProps {
   closeMenu(): void;
@@ -155,7 +154,7 @@ const TopNavMobileMenu: FC<ComponentProps> = ({closeMenu, menuOpen, smallDevice,
       <button className="TopNavMobileMenu__button" onClick={toggleMenu}>
         <Icon icon={IconType.menu} size={24} />
       </button>
-      {menuOpen && createPortal(renderMenu(), document.getElementById('popover-root')!)}
+      {menuOpen && renderMenu()}
     </div>
   );
 };

--- a/src/containers/TopNav/index.tsx
+++ b/src/containers/TopNav/index.tsx
@@ -1,6 +1,8 @@
-import React, {FC, ReactNode} from 'react';
+import React, {FC, ReactNode, useEffect, useState} from 'react';
+import {useLocation} from 'react-router-dom';
 import clsx from 'clsx';
 
+import {useBooleanState, useWindowDimensions} from 'hooks';
 import TopNavDesktopItems from './TopNavDesktopItems';
 import TopNavLogo from './TopNavLogo';
 import TopNavMobileMenu from './TopNavMobileMenu';
@@ -11,22 +13,43 @@ interface ComponentProps {
 }
 
 const TopNav: FC<ComponentProps> = ({className}) => {
+  const [mobileMenuIsOpen, toggleMobileMenu, , closeMobileMenu] = useBooleanState(false);
+  const [smallDevice, setSmallDevice] = useState(false);
+  const {pathname} = useLocation();
+  const {width} = useWindowDimensions();
+
+  useEffect(() => {
+    closeMobileMenu();
+  }, [closeMobileMenu, pathname]);
+
+  useEffect(() => {
+    if (width > 1200) closeMobileMenu();
+    setSmallDevice(width < 992);
+  }, [closeMobileMenu, smallDevice, width]);
+
   const renderRightItems = (): ReactNode => {
     return (
       <div className="TopNav__right">
         <TopNavDesktopItems />
-        <TopNavMobileMenu />
+        <TopNavMobileMenu
+          closeMenu={closeMobileMenu}
+          menuOpen={mobileMenuIsOpen}
+          smallDevice={smallDevice}
+          toggleMenu={toggleMobileMenu}
+        />
       </div>
     );
   };
 
   return (
-    <header className={clsx('TopNav', className)}>
-      <div className="TopNav__left">
-        <TopNavLogo />
-      </div>
-      {renderRightItems()}
-    </header>
+    <div className={clsx('TopNav__wrapper', {'TopNav__wrapper--mobile-menu-open': mobileMenuIsOpen})}>
+      <header className={clsx('TopNav', className)}>
+        <div className="TopNav__left">
+          <TopNavLogo />
+        </div>
+        {renderRightItems()}
+      </header>
+    </div>
   );
 };
 


### PR DESCRIPTION
Two things I wanted to fix for mobile view regarding our top nav:

1. The texts are all grey, making it seem like it's disabled
2. Our topNav component has a foggy-glass look, but the menu dropdown is pure white. This makes it look off.

Left is how our app currently looks like, and right is my proposed change:

![Screen Shot 2021-02-24 at 6 22 44 PM](https://user-images.githubusercontent.com/5943963/109093711-a98e9880-76cd-11eb-9705-b90bf3cfc15d.png)

Basically, the foggy-glass look will disapear when the dropdown is open.

I added a bunch of reviewers to this, to hopefully ensure that my change doesn't yield something unintended