### PR TITLE
[#1299] Fix contributor tasks alignment issue

### DIFF
--- a/src/components/A/A.test.tsx
+++ b/src/components/A/A.test.tsx
@@ -131,4 +131,28 @@ describe('A component', () => {
 
     expect(icon.className).toContain('test__Icon--new-window');
   });
+
+  test('new window icon has correct default iconTotalSize when not passed in', () => {
+    render(
+      <A className="test" href="/">
+        hello
+      </A>,
+    );
+    const icon = screen.getByTestId('A__Icon--new-window');
+
+    expect(icon.style).toHaveProperty('width', '20px');
+    expect(icon.style).toHaveProperty('height', '20px');
+  });
+
+  test('new window icon has correct iconTotalSize when passed in', () => {
+    render(
+      <A className="test" href="/" iconSize={12} iconTotalSize={12}>
+        hello
+      </A>,
+    );
+    const icon = screen.getByTestId('A__Icon--new-window');
+
+    expect(icon.style).toHaveProperty('width', '12px');
+    expect(icon.style).toHaveProperty('height', '12px');
+  });
 });

--- a/src/components/A/index.tsx
+++ b/src/components/A/index.tsx
@@ -11,9 +11,19 @@ interface ComponentProps {
   dataTestId?: string;
   href: string;
   newWindow?: boolean;
+  iconTotalSize?: number;
+  iconSize?: number;
 }
 
-const A: FC<ComponentProps> = ({children, className, dataTestId = 'A', href, newWindow = true}) => {
+const A: FC<ComponentProps> = ({
+  children,
+  className,
+  dataTestId = 'A',
+  href,
+  iconSize = 16,
+  iconTotalSize = 20,
+  newWindow = true,
+}) => {
   const renderIcon = newWindow && typeof children === 'string';
   const rel = newWindow ? 'noreferrer' : undefined;
   const target = newWindow ? '_blank' : '_self';
@@ -26,8 +36,8 @@ const A: FC<ComponentProps> = ({children, className, dataTestId = 'A', href, new
           className={clsx('A__Icon--new-window', {...bemify(className, '__Icon--new-window')})}
           dataTestId={`${dataTestId}__Icon--new-window`}
           icon={IconType.openInNew}
-          size={16}
-          totalSize={20}
+          size={iconSize}
+          totalSize={iconTotalSize}
         />
       )}
     </a>

--- a/src/components/ContributorTasks/index.tsx
+++ b/src/components/ContributorTasks/index.tsx
@@ -19,6 +19,8 @@ const ContributorTasks: FC<ContributorTasksProps> = ({className, tasks}) => {
           <A
             className="ContributorTasks__issue-link"
             href={`https://github.com/thenewboston-developers/${repository}/issues/${issue_id}`}
+            iconSize={12}
+            iconTotalSize={12}
           >
             {title}
           </A>


### PR DESCRIPTION
Fixes #1299 

Currently each row is not align correctly as the new window icon has larger height than the `line-height` itself. Allowing to set the new window icon to be smaller solves the issue. (Not too sure if this is the best solution)

<img width="940" alt="Screen Shot 2021-02-26 at 10 42 46 PM" src="https://user-images.githubusercontent.com/32864116/109315541-9c1c0e80-7885-11eb-908c-4aa5c01d3f79.png">
