### PR TITLE
[#1471] Improve popover accessibility

### DIFF
--- a/src/containers/TopNav/TopNavPopover/index.tsx
+++ b/src/containers/TopNav/TopNavPopover/index.tsx
@@ -39,6 +39,7 @@ const TopNavPopover: FC<ComponentProps> = ({
 }) => {
   const history = useHistory();
   const itemsRef = useRef<HTMLAnchorElement[]>([]);
+  const popoverButtonRef = useRef<HTMLButtonElement>(null);
   const {clientWidth} = useWindowDimensions();
 
   const popoverIsOpen = !!anchorEl;
@@ -56,7 +57,21 @@ const TopNavPopover: FC<ComponentProps> = ({
   const handleOptionKeyDown = (to: string, index: number, disabled?: boolean) => (
     e: KeyboardEvent<HTMLAnchorElement>,
   ): void => {
+    if (e.shiftKey && e.key === 'Tab') {
+      // Shift + Tab at first item -> focus at last item
+      if (index === 0) {
+        e.preventDefault();
+        itemsRef.current[items.length - 1]?.focus();
+      }
+      return;
+    }
+
     if (e.key === 'Tab') {
+      // Tab at the last item -> focus at first item
+      if (index === items.length - 1) {
+        e.preventDefault();
+        itemsRef.current[0]?.focus();
+      }
       return;
     }
 
@@ -64,6 +79,7 @@ const TopNavPopover: FC<ComponentProps> = ({
 
     if (e.key === 'Escape') {
       unsetAnchorEl();
+      popoverButtonRef.current?.focus(); // focus back to popover button when close popover
       return;
     }
 
@@ -99,7 +115,7 @@ const TopNavPopover: FC<ComponentProps> = ({
 
   return (
     <>
-      <button className={clsx('TopNavPopover', className)} onClick={handleButtonClick}>
+      <button className={clsx('TopNavPopover', className)} onClick={handleButtonClick} ref={popoverButtonRef}>
         {customButtonContent || (
           <>
             {buttonText}


### PR DESCRIPTION
Fixes #1471

Current:
- TAB after the last popover item will result back to focus on the URL
- Escape from popover will result back to focus on the URL

https://user-images.githubusercontent.com/32864116/110208998-1c192880-7ec5-11eb-80a2-47c83251b8b9.mp4

This PR improves popover accessibility by:
- trapping focus to popover items within the popover
- when escape from popover, focus on the popover button

After:

https://user-images.githubusercontent.com/32864116/110208946-d4929c80-7ec4-11eb-92ff-6c76292d336a.mp4

c54c04774efaae20746fd3f29cdd619fea512e119bc1082b863572b2e8844104