### PR TITLE
[#1480] Add github_username and profile_image field to EditUserModal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "react-copy-to-clipboard": "^5.0.2",
         "react-dom": "^17.0.1",
         "react-helmet-async": "^1.0.7",
+        "react-image": "^4.0.3",
         "react-leaflet": "^2.8.0",
         "react-redux": "^7.2.2",
         "react-router-dom": "^5.2.0",
@@ -7136,17 +7137,17 @@
       "integrity": "sha512-J8OHxOeJkoSLgBXfV9BHgKccgfLMHh+CoeRo6wJsi6m0k3otaxS/5vrHpMNSEYY4MISwewqanPOuhAtuE8riQQ=="
     },
     "node_modules/elliptic": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
       "dependencies": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
         "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "node_modules/elliptic/node_modules/bn.js": {
@@ -18441,6 +18442,16 @@
         "prop-types": "^15.7.2",
         "react-fast-compare": "^3.2.0",
         "shallowequal": "^1.1.0"
+      }
+    },
+    "node_modules/react-image": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/react-image/-/react-image-4.0.3.tgz",
+      "integrity": "sha512-19MUK9u1qaw9xys8XEsVkSpVhHctEBUeYFvrLTe1PN+4w5Co13AN2WA7xtBshPM6SthsOj77SlDrEAeOaJpf7g==",
+      "peerDependencies": {
+        "@babel/runtime": ">=7",
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-input-autosize": {
@@ -30366,17 +30377,17 @@
       "integrity": "sha512-J8OHxOeJkoSLgBXfV9BHgKccgfLMHh+CoeRo6wJsi6m0k3otaxS/5vrHpMNSEYY4MISwewqanPOuhAtuE8riQQ=="
     },
     "elliptic": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
       "requires": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
         "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
       },
       "dependencies": {
         "bn.js": {
@@ -39421,6 +39432,12 @@
         "react-fast-compare": "^3.2.0",
         "shallowequal": "^1.1.0"
       }
+    },
+    "react-image": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/react-image/-/react-image-4.0.3.tgz",
+      "integrity": "sha512-19MUK9u1qaw9xys8XEsVkSpVhHctEBUeYFvrLTe1PN+4w5Co13AN2WA7xtBshPM6SthsOj77SlDrEAeOaJpf7g==",
+      "requires": {}
     },
     "react-input-autosize": {
       "version": "2.2.2",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "react-copy-to-clipboard": "^5.0.2",
     "react-dom": "^17.0.1",
     "react-helmet-async": "^1.0.7",
+    "react-image": "^4.0.3",
     "react-leaflet": "^2.8.0",
     "react-redux": "^7.2.2",
     "react-router-dom": "^5.2.0",

--- a/src/components/Avatar/Avatar.test.tsx
+++ b/src/components/Avatar/Avatar.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {render, screen} from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
+import DefaultUserAvatar from 'assets/images/default-avatar.png';
 import Avatar, {AvatarProps, getImageSizeBasedOnDeviceRatio} from '.';
 
 describe('Avatar component', () => {
@@ -95,23 +96,26 @@ describe('Avatar component', () => {
   });
 
   describe('renders fallback component', () => {
-    it('renders fallback component if empty stings passed as src', () => {
+    it('renders fallback component if empty strings passed as src', () => {
       const props = {...baseProps, src: ''};
       render(<Avatar {...props} />);
 
       const el = screen.getByTestId('Avatar--placeholder');
 
       expect(el).toBeTruthy();
+      expect(el).toHaveAttribute('alt', baseProps.alt);
+      expect(el).toHaveAttribute('src', DefaultUserAvatar);
+      expect(el).toHaveAttribute('height', props.size.toString());
+      expect(el).toHaveAttribute('width', props.size.toString());
     });
 
-    it('renders fallback component with size passed in', () => {
-      const props = {...baseProps, src: ''};
+    it('renders fallback component with className passed in', () => {
+      const props = {...baseProps, className: 'Test', src: ''};
       render(<Avatar {...props} />);
 
       const el = screen.getByTestId('Avatar--placeholder');
 
-      expect(el.style).toHaveProperty('height', `${props.size}px`);
-      expect(el.style).toHaveProperty('width', `${props.size}px`);
+      expect(el.className).toContain('Test');
     });
   });
 });

--- a/src/components/Avatar/Avatar.test.tsx
+++ b/src/components/Avatar/Avatar.test.tsx
@@ -2,36 +2,43 @@ import React from 'react';
 import {render, screen} from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
-import DefaultUserAvatar from 'assets/images/default-avatar.png';
-import Avatar, {AvatarProps, getImageSizeBasedOnDeviceRatio} from '.';
+import Avatar, {AvatarProps, getFormattedSrc, getImageSizeBasedOnDeviceRatio} from '.';
 
 describe('Avatar component', () => {
   const baseProps: AvatarProps = {
-    alt: 'Test Text',
     size: 60,
-    src: 'https://avatars.githubusercontent.com/u/29539278?s=460&u=c949af33256607d5e1d93958398a139ff1d67227&v=4',
+    src: 'https://thenewboston.com',
   };
 
   afterEach(() => {
     jest.restoreAllMocks();
   });
 
-  it('renders image', () => {
+  it('renders fallback image', () => {
     render(<Avatar {...baseProps} />);
-
-    expect(screen.getByTestId('Avatar')).toBeTruthy();
+    expect(screen.getByTestId('Avatar--placeholder')).toBeTruthy();
   });
 
-  it('renders image with default className', () => {
+  it('renders fallback image with default className', () => {
     render(<Avatar {...baseProps} />);
 
-    expect(screen.getByTestId('Avatar')).toHaveClass('Avatar');
+    expect(screen.getByTestId('Avatar--placeholder')).toHaveClass('Avatar');
+    expect(screen.getByTestId('Avatar--placeholder')).toHaveClass('Avatar--placeholder');
   });
 
-  it('renders image with className passed in', () => {
+  it('renders fallback image with className passed in', () => {
     render(<Avatar className="test" {...baseProps} />);
 
-    expect(screen.getByTestId('Avatar')).toHaveClass('test');
+    expect(screen.getByTestId('Avatar--placeholder')).toHaveClass('test');
+  });
+
+  it('renders fallback image with size passed in', () => {
+    render(<Avatar className="test" {...baseProps} />);
+
+    const placeholder = screen.getByTestId('Avatar--placeholder');
+
+    expect(placeholder).toHaveStyle({'min-height': `${baseProps.size.toString()}px`});
+    expect(placeholder).toHaveStyle({'min-width': `${baseProps.size.toString()}px`});
   });
 
   describe('getImageSizeBasedOnDeviceRatio', () => {
@@ -50,72 +57,29 @@ describe('Avatar component', () => {
     });
   });
 
-  describe('renders image with updated url', () => {
-    it('renders image with github url', () => {
+  describe('getFormattedSrc', () => {
+    it('gets correct url for github', () => {
+      const url =
+        'https://avatars.githubusercontent.com/u/29539278?s=460&u=c949af33256607d5e1d93958398a139ff1d67227&v=4';
       const updatedUrl = 'https://avatars.githubusercontent.com/u/29539278?s=60';
-      render(<Avatar {...baseProps} />);
+      const result = getFormattedSrc(url, baseProps.size);
 
-      const el = screen.getByTestId('Avatar');
-
-      expect(el).toHaveAttribute('src', updatedUrl);
+      expect(result).toEqual(updatedUrl);
     });
 
-    it('renders image with slack url', () => {
-      const props = {...baseProps, src: 'https://ca.slack-edge.com/T07PJD1FZ-U01EDKBT8LA-a17fa362a21e-512'};
+    it('gets correct url for slack', () => {
+      const url = 'https://ca.slack-edge.com/T07PJD1FZ-U01EDKBT8LA-a17fa362a21e-512';
       const updatedUrl = 'https://ca.slack-edge.com/T07PJD1FZ-U01EDKBT8LA-a17fa362a21e-60';
-      render(<Avatar {...props} />);
+      const result = getFormattedSrc(url, baseProps.size);
 
-      const el = screen.getByTestId('Avatar');
-
-      expect(el).toHaveAttribute('src', updatedUrl);
+      expect(result).toEqual(updatedUrl);
     });
 
-    it('renders image with any other url', () => {
-      const props = {...baseProps, src: 'https://via.placeholder.com/150'};
-      render(<Avatar {...props} />);
+    it('gets correct url for any other url', () => {
+      const url = 'https://via.placeholder.com/150';
+      const result = getFormattedSrc(url, baseProps.size);
 
-      const el = screen.getByTestId('Avatar');
-
-      expect(el).toHaveAttribute('src', props.src);
-    });
-  });
-
-  it('renders image with alt text passed in', () => {
-    render(<Avatar {...baseProps} />);
-
-    expect(screen.getByTestId('Avatar')).toHaveAttribute('alt', baseProps.alt);
-  });
-
-  it('renders image with size passed in', () => {
-    render(<Avatar {...baseProps} />);
-
-    const el = screen.getByTestId('Avatar');
-
-    expect(el).toHaveAttribute('height', baseProps.size.toString());
-    expect(el).toHaveAttribute('width', baseProps.size.toString());
-  });
-
-  describe('renders fallback component', () => {
-    it('renders fallback component if empty strings passed as src', () => {
-      const props = {...baseProps, src: ''};
-      render(<Avatar {...props} />);
-
-      const el = screen.getByTestId('Avatar--placeholder');
-
-      expect(el).toBeTruthy();
-      expect(el).toHaveAttribute('alt', baseProps.alt);
-      expect(el).toHaveAttribute('src', DefaultUserAvatar);
-      expect(el).toHaveAttribute('height', props.size.toString());
-      expect(el).toHaveAttribute('width', props.size.toString());
-    });
-
-    it('renders fallback component with className passed in', () => {
-      const props = {...baseProps, className: 'Test', src: ''};
-      render(<Avatar {...props} />);
-
-      const el = screen.getByTestId('Avatar--placeholder');
-
-      expect(el.className).toContain('Test');
+      expect(result).toEqual(url);
     });
   });
 });

--- a/src/components/Avatar/index.tsx
+++ b/src/components/Avatar/index.tsx
@@ -1,6 +1,8 @@
 import React, {FC, useEffect, useState} from 'react';
 import clsx from 'clsx';
 
+import DefaultUserAvatar from 'assets/images/default-avatar.png';
+
 import './Avatar.scss';
 
 export interface AvatarProps {
@@ -48,10 +50,14 @@ const Avatar: FC<AvatarProps> = ({alt, className, size, src}) => {
       width={size}
     />
   ) : (
-    <div
+    <img
+      alt={alt}
       className={clsx('Avatar', 'Avater--placeholder', className)}
       data-testid="Avatar--placeholder"
-      style={{height: size, width: size}}
+      height={size}
+      loading="lazy"
+      src={DefaultUserAvatar}
+      width={size}
     />
   );
 };

--- a/src/components/Avatar/index.tsx
+++ b/src/components/Avatar/index.tsx
@@ -6,7 +6,6 @@ import DefaultUserAvatar from 'assets/images/default-avatar.png';
 import './Avatar.scss';
 
 export interface AvatarProps {
-  alt: string;
   className?: string;
   size: number;
   src: string;
@@ -17,7 +16,7 @@ export const getImageSizeBasedOnDeviceRatio = (size: number): number => {
   return size * devicePixelRatio;
 };
 
-const Avatar: FC<AvatarProps> = ({alt, className, size, src}) => {
+const Avatar: FC<AvatarProps> = ({className, size, src}) => {
   const [source, setSource] = useState<string>('');
 
   useEffect(() => {
@@ -41,7 +40,7 @@ const Avatar: FC<AvatarProps> = ({alt, className, size, src}) => {
 
   return source?.length ? (
     <img
-      alt={alt}
+      alt="Avatar"
       className={clsx('Avatar', className)}
       data-testid="Avatar"
       height={size}
@@ -51,7 +50,7 @@ const Avatar: FC<AvatarProps> = ({alt, className, size, src}) => {
     />
   ) : (
     <img
-      alt={alt}
+      alt="Avatar"
       className={clsx('Avatar', 'Avater--placeholder', className)}
       data-testid="Avatar--placeholder"
       height={size}

--- a/src/components/Avatar/index.tsx
+++ b/src/components/Avatar/index.tsx
@@ -1,4 +1,7 @@
-import React, {FC, useEffect, useState} from 'react';
+/* eslint-disable react/jsx-props-no-spreading */
+
+import React, {FC, Suspense, useEffect, useState} from 'react';
+import {useImage} from 'react-image';
 import clsx from 'clsx';
 
 import DefaultUserAvatar from 'assets/images/default-avatar.png';
@@ -16,48 +19,61 @@ export const getImageSizeBasedOnDeviceRatio = (size: number): number => {
   return size * devicePixelRatio;
 };
 
-const Avatar: FC<AvatarProps> = ({className, size, src}) => {
-  const [source, setSource] = useState<string>('');
+export const getFormattedSrc = (src: string, size: number): string => {
+  try {
+    const updatedSize = getImageSizeBasedOnDeviceRatio(size);
+    if (src.includes('github')) {
+      const [path] = src.split('?');
+      return `${path}?s=${updatedSize}`;
+    }
+    if (src.includes('slack')) {
+      const srcSplitArr = src.split('-');
+      srcSplitArr.pop();
+      const path = srcSplitArr.join('-');
+      return `${path}-${updatedSize}`;
+    }
+
+    return src;
+  } catch (error) {
+    return '';
+  }
+};
+
+const AvatarImgWithFallback: FC<AvatarProps> = ({className, size, src}) => {
+  const [srcPrimary, setSrcPrimary] = useState<string>('');
+  const {src: srcWithFallback} = useImage({srcList: [srcPrimary, DefaultUserAvatar]});
 
   useEffect(() => {
-    try {
-      const updatedSize = getImageSizeBasedOnDeviceRatio(size);
-      if (src.includes('github')) {
-        const [path] = src.split('?');
-        setSource(`${path}?s=${updatedSize}`);
-      } else if (src.includes('slack')) {
-        const srcSplitArr = src.split('-');
-        srcSplitArr.pop();
-        const path = srcSplitArr.join('-');
-        setSource(`${path}-${updatedSize}`);
-      } else {
-        setSource(src);
-      }
-    } catch (error) {
-      setSource('');
-    }
+    setSrcPrimary(getFormattedSrc(src, size));
   }, [src, size]);
 
-  return source?.length ? (
+  return (
     <img
       alt="Avatar"
       className={clsx('Avatar', className)}
+      crossOrigin="anonymous"
       data-testid="Avatar"
       height={size}
-      loading="lazy"
-      src={source}
+      key={srcWithFallback}
+      src={srcWithFallback}
       width={size}
     />
-  ) : (
-    <img
-      alt="Avatar"
-      className={clsx('Avatar', 'Avater--placeholder', className)}
-      data-testid="Avatar--placeholder"
-      height={size}
-      loading="lazy"
-      src={DefaultUserAvatar}
-      width={size}
-    />
+  );
+};
+
+const Avatar: FC<AvatarProps> = ({className, size, ...props}) => {
+  return (
+    <Suspense
+      fallback={
+        <div
+          className={clsx('Avatar', 'Avatar--placeholder', className)}
+          data-testid="Avatar--placeholder"
+          style={{minHeight: size, minWidth: size}}
+        />
+      }
+    >
+      <AvatarImgWithFallback className={className} size={size} {...props} />
+    </Suspense>
   );
 };
 

--- a/src/components/FormComponents/FormTextArea/index.tsx
+++ b/src/components/FormComponents/FormTextArea/index.tsx
@@ -11,7 +11,7 @@ import {renderFormError, renderFormLabel} from 'utils/forms';
 
 type ComponentProps = BaseFormComponentProps<BaseInputProps>;
 
-const FormTextArea: FC<ComponentProps> = ({hideErrorText = false, label, required, ...baseInputProps}) => {
+const FormTextArea: FC<ComponentProps> = ({hideErrorText = false, label, required = false, ...baseInputProps}) => {
   const {className, name} = baseInputProps;
   const {errors, touched} = useFormContext();
   const error = !!errors[name] && !!touched[name];

--- a/src/containers/EditUserModal/EditUserModalFields.tsx
+++ b/src/containers/EditUserModal/EditUserModalFields.tsx
@@ -14,7 +14,7 @@ export type FormValues = typeof initialValues;
 const EditUserModalFields: FC = () => {
   return (
     <>
-      <FormInput label="Display Name" name="displayName" required />
+      <FormInput label="Display Name" name="displayName" focused required />
       <FormInput label="Github Username" name="githubUsername" />
       <FormInput label="Slack Name" name="slackName" />
       <FormTextArea label="Account Number" name="accountNumber" />

--- a/src/containers/EditUserModal/EditUserModalFields.tsx
+++ b/src/containers/EditUserModal/EditUserModalFields.tsx
@@ -4,6 +4,8 @@ import {FormInput, FormTextArea} from 'components/FormComponents';
 export const initialValues = {
   accountNumber: '',
   displayName: '',
+  githubUsername: '',
+  profileImageUrl: '',
   slackName: '',
 };
 
@@ -12,9 +14,11 @@ export type FormValues = typeof initialValues;
 const EditUserModalFields: FC = () => {
   return (
     <>
-      <FormInput label="Display Name" name="displayName" />
+      <FormInput label="Display Name" name="displayName" required />
+      <FormInput label="Github Username" name="githubUsername" />
       <FormInput label="Slack Name" name="slackName" />
       <FormTextArea label="Account Number" name="accountNumber" />
+      <FormTextArea label="Profile Image URL" name="profileImageUrl" />
     </>
   );
 };

--- a/src/containers/EditUserModal/index.tsx
+++ b/src/containers/EditUserModal/index.tsx
@@ -56,13 +56,10 @@ const EditUserModal: FC<ComponentProps> = ({close}) => {
   };
 
   const validationSchema = yup.object().shape({
-    accountNumber: yup
-      .string()
-      .length(64, 'Account Number must be 64 characters long')
-      .required('This field is required'),
+    accountNumber: yup.string().length(64, 'Account Number must be 64 characters long'),
     displayName: yup.string().required('This field is required'),
     githubUsername: yup.string(),
-    profileImageUrl: yup.string(),
+    profileImageUrl: yup.string().url('Must be a valid URL'),
     slackName: yup.string(),
   });
 

--- a/src/containers/EditUserModal/index.tsx
+++ b/src/containers/EditUserModal/index.tsx
@@ -24,17 +24,27 @@ const EditUserModal: FC<ComponentProps> = ({close}) => {
   const initialValues = {
     accountNumber: activeUser.account_number || '',
     displayName: activeUser.display_name || '',
+    githubUsername: activeUser.github_username || '',
+    profileImageUrl: activeUser.profile_image || '',
     slackName: activeUser.slack_username || '',
   };
 
-  const handleSubmit = async ({accountNumber, displayName, slackName}: FormValues): Promise<void> => {
+  const handleSubmit = async ({
+    accountNumber,
+    displayName,
+    githubUsername,
+    profileImageUrl,
+    slackName,
+  }: FormValues): Promise<void> => {
     try {
       setSubmitting(true);
       await dispatch(
         editUser({
           account_number: accountNumber,
           display_name: displayName,
+          github_username: githubUsername,
           pk: activeUser.pk,
+          profile_image: profileImageUrl,
           slack_username: slackName,
         }),
       );
@@ -51,6 +61,8 @@ const EditUserModal: FC<ComponentProps> = ({close}) => {
       .length(64, 'Account Number must be 64 characters long')
       .required('This field is required'),
     displayName: yup.string().required('This field is required'),
+    githubUsername: yup.string(),
+    profileImageUrl: yup.string(),
     slackName: yup.string(),
   });
 

--- a/src/containers/Leaderboard/LeaderboardContributor/index.tsx
+++ b/src/containers/Leaderboard/LeaderboardContributor/index.tsx
@@ -43,7 +43,7 @@ const LeaderboardContributor: FC<ComponentProps> = ({
       >
         {rank}
       </div>
-      <Avatar alt={github_username} size={width > 768 ? 178 : 54} src={github_avatar_url} />
+      <Avatar size={width > 768 ? 178 : 54} src={github_avatar_url} />
     </div>
   );
 

--- a/src/containers/Profile/ProfileInfo/index.tsx
+++ b/src/containers/Profile/ProfileInfo/index.tsx
@@ -2,7 +2,6 @@ import React, {FC} from 'react';
 import {useSelector} from 'react-redux';
 import {useParams} from 'react-router-dom';
 
-import DefaultUserAvatar from 'assets/images/default-avatar.png';
 import {A, Avatar, CopyableAccountNumber, Icon, IconType, Qr} from 'components';
 import EditUserModal from 'containers/EditUserModal';
 import {useBooleanState} from 'hooks';
@@ -78,7 +77,7 @@ const ProfileInfo: FC<ComponentProps> = ({user}) => {
             alt={user.github_username}
             className="ProfileInfo__profile-picture"
             size={178}
-            src={user.profile_image || DefaultUserAvatar}
+            src={user.profile_image}
           />
         </div>
         <div className="ProfileInfo__details">

--- a/src/containers/Profile/ProfileInfo/index.tsx
+++ b/src/containers/Profile/ProfileInfo/index.tsx
@@ -73,12 +73,7 @@ const ProfileInfo: FC<ComponentProps> = ({user}) => {
       <div className="ProfileInfo">
         <div className="ProfileInfo__top-section">
           {renderBackdrop(memberDetails?.isLead || false)}
-          <Avatar
-            alt={user.github_username}
-            className="ProfileInfo__profile-picture"
-            size={178}
-            src={user.profile_image}
-          />
+          <Avatar className="ProfileInfo__profile-picture" size={178} src={user.profile_image} />
         </div>
         <div className="ProfileInfo__details">
           <div className="ProfileInfo__user-details">

--- a/src/containers/SlideUpAccountDetails/index.tsx
+++ b/src/containers/SlideUpAccountDetails/index.tsx
@@ -28,7 +28,7 @@ const SlideUpAccountDetails: FC<ComponentProps> = ({account_number, close, githu
     <SlideUp className="SlideUpAccountDetails__SlideUp" close={close}>
       <div className="SlideUpAccountDetails__inner-wrapper">
         <div>
-          <Avatar alt={github_username} size={54} src={github_avatar_url} />
+          <Avatar size={54} src={github_avatar_url} />
         </div>
         {renderRight()}
       </div>

--- a/src/containers/Teams/TeamMemberCard/index.tsx
+++ b/src/containers/Teams/TeamMemberCard/index.tsx
@@ -25,7 +25,7 @@ const TeamMemberCard: FC<ComponentProps> = ({
 }) => {
   const renderAvatar = () => (
     <div className="TeamMemberCard__user-avatar">
-      <Avatar alt={displayName} size={144} src={profileImage} />
+      <Avatar size={144} src={profileImage} />
     </div>
   );
 

--- a/src/containers/TopNav/TopNavDesktopItems/index.tsx
+++ b/src/containers/TopNav/TopNavDesktopItems/index.tsx
@@ -108,10 +108,9 @@ const TopNavDesktopItems = () => {
     const {profile_image: profileImage} = activeUser;
     return (
       <TopNavPopover
+        className="TopNavDesktopItems__profile-image"
         anchorEl={activeUserAnchorEl}
-        customButtonContent={
-          <Avatar alt="profile" className="TopNavDesktopItems__profile-image" src={profileImage} size={36} />
-        }
+        customButtonContent={<Avatar src={profileImage} size={36} />}
         items={activeUserPopoverItems}
         popoverId="active-user-popover"
         setAnchorEl={setActiveUserAnchorEl}

--- a/src/containers/TopNav/TopNavDesktopItems/index.tsx
+++ b/src/containers/TopNav/TopNavDesktopItems/index.tsx
@@ -2,8 +2,7 @@ import React, {useMemo, useState} from 'react';
 import {useSelector} from 'react-redux';
 import {Link} from 'react-router-dom';
 
-import DefaultUserAvatar from 'assets/images/default-avatar.png';
-import {Button, IconType} from 'components';
+import {Avatar, Button, IconType} from 'components';
 import TopNavLink from 'containers/TopNav/TopNavLink';
 import TopNavPopover, {TopNavPopoverItemType} from 'containers/TopNav/TopNavPopover';
 import {selectActiveUser} from 'selectors/state';
@@ -111,7 +110,7 @@ const TopNavDesktopItems = () => {
       <TopNavPopover
         anchorEl={activeUserAnchorEl}
         customButtonContent={
-          <img alt="profile" className="TopNavDesktopItems__profile-image" src={profileImage || DefaultUserAvatar} />
+          <Avatar alt="profile" className="TopNavDesktopItems__profile-image" src={profileImage} size={36} />
         }
         items={activeUserPopoverItems}
         popoverId="active-user-popover"

--- a/src/data/teams.json
+++ b/src/data/teams.json
@@ -746,7 +746,7 @@
           "contributorId": "87",
           "displayName": "Nosazeme Obabueki",
           "githubUsername": "knowsarzehmeh",
-          "profileImage": "https://ca.slack-edge.com/T07PJD1FZ-U01LUSU2JEB-47e0846283d1-512",
+          "profileImage": "https://avatars.githubusercontent.com/u/28178015?v=4",
           "slackUsername": "Osaz"
         }
       }
@@ -914,7 +914,7 @@
           "contributorId": "71",
           "displayName": "Ananda",
           "githubUsername": "dhakalananda",
-          "profileImage": "https://ca.slack-edge.com/T07PJD1FZ-U01EDKBT8LA-a17fa362a21e-512",
+          "profileImage": "https://avatars.githubusercontent.com/u/43310655?v=4",
           "slackUsername": "Ananda"
         }
       },
@@ -927,7 +927,7 @@
           "contributorId": "72",
           "displayName": "Ramadhani Khamisi",
           "githubUsername": "swaiba43",
-          "profileImage": "https://ca.slack-edge.com/T07PJD1FZ-U01HRTHAG3X-236b30d5fb15-512",
+          "profileImage": "https://avatars.githubusercontent.com/u/17829082?v=4",
           "slackUsername": "swaiba43"
         }
       },
@@ -966,7 +966,7 @@
           "contributorId": "75",
           "displayName": "SohDa",
           "githubUsername": "SOHDA31",
-          "profileImage": "https://ca.slack-edge.com/T07PJD1FZ-U01E4P5AU5Q-8722ab1e52a7-512",
+          "profileImage": "https://avatars.githubusercontent.com/u/74038568?v=4",
           "slackUsername": "SohDa"
         }
       },
@@ -992,7 +992,7 @@
           "contributorId": "78",
           "displayName": "Mr9tynine",
           "githubUsername": "Mr9tynine",
-          "profileImage": "https://ca.slack-edge.com/T07PJD1FZ-U01MFD5GT5J-eae2ef782ec8-512",
+          "profileImage": "https://avatars.githubusercontent.com/u/49120625?v=4",
           "slackUsername": "Mr9tynine"
         }
       },
@@ -1464,7 +1464,7 @@
           "contributorId": "88",
           "displayName": "Muhammad Anas Azam Bhatti",
           "githubUsername": "ma2b0043",
-          "profileImage": "https://ca.slack-edge.com/T07PJD1FZ-U01M4RMJLQ0-9faa743e4f84-512",
+          "profileImage": "https://avatars.githubusercontent.com/u/60430226?v=4",
           "slackUsername": "Muhammad Anas Azam Bhatti"
         }
       },
@@ -1597,7 +1597,7 @@
           "contributorId": "64",
           "displayName": "Francis Polignano",
           "githubUsername": "franchyze923",
-          "profileImage": "https://ca.slack-edge.com/T07PJD1FZ-U01DQAFHKE3-aad7fcf8fa5b-512",
+          "profileImage": "https://avatars.githubusercontent.com/u/9319623?v=4",
           "slackUsername": "Francis Polignano"
         }
       }


### PR DESCRIPTION
Fixes #1480 

Made `DefaultUserAvatar` as the fallback Avatar, updated tests based on that too.

Modal:

<img width="446" alt="Screen Shot 2021-03-07 at 2 29 15 PM" src="https://user-images.githubusercontent.com/32864116/110231263-9becd480-7f51-11eb-9978-c5f9c8cc42e3.png">

Profile after setting `github_username` and `profile_image`:

<img width="1372" alt="Screen Shot 2021-03-07 at 3 26 58 PM" src="https://user-images.githubusercontent.com/32864116/110232596-972c1e80-7f59-11eb-8fc7-72e2bc5903e8.png">

