### PR TITLE
Add tests for DocSubHeader

### DIFF
--- a/src/components/DocWrapper/DocSubHeader/DocSubHeader.test.tsx
+++ b/src/components/DocWrapper/DocSubHeader/DocSubHeader.test.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import {render, screen} from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+import DocSubHeader from '.';
+
+describe('DocSubHeader component', () => {
+  test('renders with text passed in', () => {
+    render(<DocSubHeader className="test">Hello World!</DocSubHeader>);
+
+    expect(screen.getByText('Hello World!')).toBeTruthy();
+  });
+
+  test('renders proper default className', () => {
+    render(<DocSubHeader>Hello World!</DocSubHeader>);
+    const el = screen.getByTestId('DocSubHeader');
+    expect(el.className).toBe('DocSubHeader');
+  });
+
+  test('renders with classNames passed in', () => {
+    render(<DocSubHeader className="test">Hello World!</DocSubHeader>);
+    const docSubHeader = screen.getByTestId('DocSubHeader');
+
+    expect(docSubHeader.className).toContain('test');
+  });
+});

--- a/src/components/DocWrapper/DocSubHeader/index.tsx
+++ b/src/components/DocWrapper/DocSubHeader/index.tsx
@@ -8,7 +8,11 @@ interface ComponentProps {
 }
 
 const DocSubHeader: FC<ComponentProps> = ({children, className}) => {
-  return <h3 className={clsx('DocSubHeader', className)}>{children}</h3>;
+  return (
+    <h3 className={clsx('DocSubHeader', className)} data-testid="DocSubHeader">
+      {children}
+    </h3>
+  );
 };
 
 export default DocSubHeader;


### PR DESCRIPTION
Fixes: https://github.com/thenewboston-developers/Website/issues/1349

**Tests:**
- renders with text passed in
- renders proper default className
- renders with classNames passed in


**Account Number:** `0f92e975101eb96cea80dce430d74efd3172fa229377818d467ded85dcf2ab6c`