### PR TITLE
[#1539] Set width of mobile popover items

### DIFF
--- a/src/containers/TopNav/TopNavMobileMenu/TopNavMobileMenu.scss
+++ b/src/containers/TopNav/TopNavMobileMenu/TopNavMobileMenu.scss
@@ -133,6 +133,7 @@ $top-nav-height: 60px;
     margin-top: 24px;
     padding: 0;
     text-align: unset;
+    width: fit-content;
 
     &:hover {
       text-decoration: underline;

--- a/src/containers/TopNav/TopNavMobileMenu/TopNavMobileMenu.scss
+++ b/src/containers/TopNav/TopNavMobileMenu/TopNavMobileMenu.scss
@@ -46,7 +46,6 @@ $top-nav-height: 60px;
     border: none;
     display: flex;
     justify-content: space-between;
-    outline: none;
     padding: unset;
   }
 


### PR DESCRIPTION
Fixes #1539 

<img width="523" alt="Screen Shot 2021-03-12 at 11 29 16 PM" src="https://user-images.githubusercontent.com/32864116/110961437-c643f500-838a-11eb-80a0-14d411d50e4b.png">
