### PR TITLE
[#1577] ! Use Prism as language highlighter to include jsx

### DIFF
--- a/src/components/CodeSnippet/BaseCodeSnippet/BaseCodeSnippet.test.tsx
+++ b/src/components/CodeSnippet/BaseCodeSnippet/BaseCodeSnippet.test.tsx
@@ -27,20 +27,20 @@ describe('RequestResponseSnippet', () => {
     expect(screen.getByText("console.log('TNB is heading to the moon');")).toBeTruthy();
   });
 
-  it('renders with the default obsidian style', () => {
+  it('renders with the default duotone dark style', () => {
     render(<BaseCodeSnippet {...baseProps} />);
 
-    // distinct style for obsidian in hljs
-    expect(screen.getByTestId(baseTestId).style).toHaveProperty('background-color', 'rgb(40, 43, 46)');
-    expect(screen.getByTestId(baseTestId).style).toHaveProperty('color', 'rgb(224, 226, 228)');
+    // distinct style for duotone dark in prism
+    expect(screen.getByTestId(baseTestId).style).toHaveProperty('background-color', 'rgb(42, 39, 52)');
+    expect(screen.getByTestId(baseTestId).style).toHaveProperty('color', 'rgb(154, 134, 253)');
   });
 
   it('renders without crashing when light passed in', () => {
     render(<BaseCodeSnippet {...baseProps} light />);
 
-    // distinct style for routeros in hljs
-    expect(screen.getByTestId(baseTestId).style).toHaveProperty('background-color', 'rgb(240, 240, 240)');
-    expect(screen.getByTestId(baseTestId).style).toHaveProperty('color', 'rgb(68, 68, 68)');
+    // distinct style for solarized light in prism
+    expect(screen.getByTestId(baseTestId).style).toHaveProperty('background-color', 'rgb(253, 246, 227)');
+    expect(screen.getByTestId(baseTestId).style).toHaveProperty('color', 'rgb(101, 123, 131)');
   });
 
   it('renders with showLineNumbers passed in', () => {

--- a/src/components/CodeSnippet/BaseCodeSnippet/index.tsx
+++ b/src/components/CodeSnippet/BaseCodeSnippet/index.tsx
@@ -1,12 +1,12 @@
 import React, {FC} from 'react';
-import {Light as SyntaxHighlighter} from 'react-syntax-highlighter';
-import {obsidian, routeros} from 'react-syntax-highlighter/dist/esm/styles/hljs';
-import bashLang from 'react-syntax-highlighter/dist/esm/languages/hljs/bash';
-import jsonLang from 'react-syntax-highlighter/dist/esm/languages/hljs/json';
+import {PrismLight as SyntaxHighlighter} from 'react-syntax-highlighter';
+import {duotoneDark, solarizedlight} from 'react-syntax-highlighter/dist/esm/styles/prism';
+import bashLang from 'react-syntax-highlighter/dist/esm/languages/prism/bash';
+import jsonLang from 'react-syntax-highlighter/dist/esm/languages/prism/json';
 import jsxLang from 'react-syntax-highlighter/dist/esm/languages/prism/jsx';
-import pythonLang from 'react-syntax-highlighter/dist/esm/languages/hljs/python';
-import scssLang from 'react-syntax-highlighter/dist/esm/languages/hljs/scss';
-import typescriptLang from 'react-syntax-highlighter/dist/esm/languages/hljs/typescript';
+import pythonLang from 'react-syntax-highlighter/dist/esm/languages/prism/python';
+import scssLang from 'react-syntax-highlighter/dist/esm/languages/prism/scss';
+import typescriptLang from 'react-syntax-highlighter/dist/esm/languages/prism/typescript';
 
 export enum SnippetLang {
   bash = 'bash',
@@ -36,7 +36,7 @@ const BaseCodeSnippet: FC<BaseCodeSnippetProps> = ({code, language, light = fals
     <SyntaxHighlighter
       language={language}
       showLineNumbers={showLineNumbers}
-      style={light ? routeros : obsidian}
+      style={light ? solarizedlight : duotoneDark}
       data-testid="BaseCodeSnippet"
     >
       {code}

--- a/src/components/CodeSnippet/CodeSnippet/CodeSnippet.test.tsx
+++ b/src/components/CodeSnippet/CodeSnippet/CodeSnippet.test.tsx
@@ -35,8 +35,8 @@ describe('CodeSnippet component', () => {
     expect(code).toBeTruthy();
     expect(code).toHaveClass('language-bash');
 
-    expect(screen.getByTestId('BaseCodeSnippet').style).toHaveProperty('background-color', 'rgb(240, 240, 240)');
-    expect(screen.getByTestId('BaseCodeSnippet').style).toHaveProperty('color', 'rgb(68, 68, 68)');
+    expect(screen.getByTestId('BaseCodeSnippet').style).toHaveProperty('background-color', 'rgb(253, 246, 227)');
+    expect(screen.getByTestId('BaseCodeSnippet').style).toHaveProperty('color', 'rgb(101, 123, 131)');
   });
 
   test('renders dark code for language-json', () => {
@@ -45,8 +45,8 @@ describe('CodeSnippet component', () => {
     expect(code).toBeTruthy();
     expect(code).toHaveClass('language-json');
 
-    expect(screen.getByTestId('BaseCodeSnippet').style).toHaveProperty('background-color', 'rgb(40, 43, 46)');
-    expect(screen.getByTestId('BaseCodeSnippet').style).toHaveProperty('color', 'rgb(224, 226, 228)');
+    expect(screen.getByTestId('BaseCodeSnippet').style).toHaveProperty('background-color', 'rgb(42, 39, 52)');
+    expect(screen.getByTestId('BaseCodeSnippet').style).toHaveProperty('color', 'rgb(154, 134, 253)');
   });
 
   test('renders component with custom className CustomCodeSnippet', () => {


### PR DESCRIPTION
Fixes #1577

`hljs` does not include `jsx` as language, which causes `jsx` to not able to be registered properly. Switching to use `Prism` will solve the issue as it includes all languages listed in our `SnippetLang` enum. [Reference](https://github.com/react-syntax-highlighter/react-syntax-highlighter/blob/master/AVAILABLE_LANGUAGES_PRISM.MD)

However, the style of the code snippets need to be changed as `prism` has its own pre-built styles that are different from `hljs`. I have chosen `solarizedLight` for light backgrounds and `duotoneDark` for dark background.

`solarizedLight`: (bash code snippets)

<img width="767" alt="Screen Shot 2021-03-20 at 11 06 50 PM" src="https://user-images.githubusercontent.com/32864116/111875025-a5a31d00-89d2-11eb-9ba3-32bcbe649be3.png">

`duotoneDark`: (all other code snippets)

<img width="678" alt="Screen Shot 2021-03-20 at 11 01 43 PM" src="https://user-images.githubusercontent.com/32864116/111875028-a9cf3a80-89d2-11eb-9b83-e1118b364b3d.png">

P.S. its fine for this PR to not be paid as it was my mistake to not spot the error previously
