### PR TITLE
Add handling of invalid url path for Openings page

### DIFF
--- a/src/containers/Openings/index.tsx
+++ b/src/containers/Openings/index.tsx
@@ -26,8 +26,12 @@ const Openings: FC = () => {
   const [categoryFilter, setCategoryFilter] = useState<OpeningCategory>(OpeningCategory.all);
 
   useEffect(() => {
-    setCategoryFilter(categoryParam);
-  }, [categoryParam]);
+    if (OPENING_CATEGORY_FILTERS.some((filter) => filter.pathname === categoryParam)) {
+      setCategoryFilter(categoryParam);
+    } else {
+      history.replace('/openings/All');
+    }
+  }, [categoryParam, history]);
 
   const filteredOpenings = useMemo(
     () =>


### PR DESCRIPTION
Fixes #1615 

Redirect user back to the `All` path if the supplied path is invalid:


https://user-images.githubusercontent.com/32864116/112709005-c0a0f000-8ef0-11eb-9b16-93e22f356aec.mp4

