### PR TITLE
[#1617] Add apply button to Openings header and OpeningDetails header

### DIFF
--- a/src/constants/urls.ts
+++ b/src/constants/urls.ts
@@ -1,0 +1,2 @@
+export const OPENINGS_GOOGLE_FORM_LINK =
+  'https://docs.google.com/forms/d/e/1FAIpQLSf4Mk-vxO3Nl193LkCSGPOrrT5uDvA27peH8du7hSnfUsxb0A/viewform';

--- a/src/containers/Openings/OpeningDetails/OpeningDetails.scss
+++ b/src/containers/Openings/OpeningDetails/OpeningDetails.scss
@@ -16,6 +16,12 @@
     }
   }
 
+  &__actions-container {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
+  }
+
   &__application-method-container {
     margin-bottom: 16px;
   }

--- a/src/containers/Openings/OpeningDetails/index.tsx
+++ b/src/containers/Openings/OpeningDetails/index.tsx
@@ -1,7 +1,8 @@
 import React, {FC, ReactNode} from 'react';
 import {useHistory, useLocation} from 'react-router-dom';
 
-import {A, Icon, IconType} from 'components';
+import {A, Button, Icon, IconType} from 'components';
+import {OPENINGS_GOOGLE_FORM_LINK} from 'constants/urls';
 import {Opening} from 'types/openings';
 
 import './OpeningDetails.scss';
@@ -54,9 +55,12 @@ const OpeningDetails: FC<ComponentProps> = ({opening}) => {
 
   return (
     <div className="OpeningDetails">
-      <div className="OpeningDetails__back-container" onClick={handleBackClick} role="button" tabIndex={0}>
-        <Icon className="OpeningDetails__back-icon" icon={IconType.arrowLeft} />
-        <span className="OpeningDetails__back-text">Back</span>
+      <div className="OpeningDetails__actions-container">
+        <div className="OpeningDetails__back-container" onClick={handleBackClick} role="button" tabIndex={0}>
+          <Icon className="OpeningDetails__back-icon" icon={IconType.arrowLeft} />
+          <span className="OpeningDetails__back-text">Back</span>
+        </div>
+        <Button onClick={() => window.open(OPENINGS_GOOGLE_FORM_LINK)}>Apply</Button>
       </div>
       {renderContent()}
     </div>

--- a/src/containers/Openings/Openings.scss
+++ b/src/containers/Openings/Openings.scss
@@ -23,11 +23,17 @@
     padding: 12px 0 48px;
   }
 
+  &__opening-list-heading-container {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
+    margin: 16px 54px 36px;
+  }
+
   &__opening-list-heading {
     font-size: 36px;
     font-weight: 300;
     line-height: 1.25;
-    margin: 16px 54px 36px;
   }
 
   @media (max-width: 992px) {
@@ -52,7 +58,7 @@
   }
 
   @media (max-width: 768px) {
-    &__opening-list-heading {
+    &__opening-list-heading-container {
       margin: 16px 42px 36px;
     }
   }

--- a/src/containers/Openings/index.tsx
+++ b/src/containers/Openings/index.tsx
@@ -1,7 +1,8 @@
 import React, {FC, ReactNode, useCallback, useEffect, useMemo, useState} from 'react';
 import {useHistory, useParams} from 'react-router-dom';
 
-import {BreadcrumbMenu, EmptyPage, FlatNavLinks, PageTitle} from 'components';
+import {Button, BreadcrumbMenu, EmptyPage, FlatNavLinks, PageTitle} from 'components';
+import {OPENINGS_GOOGLE_FORM_LINK} from 'constants/urls';
 import {getOpenings} from 'utils/data';
 import {NavOption} from 'types/option';
 import {OpeningCategory, OpeningsUrlParams} from 'types/openings';
@@ -95,7 +96,10 @@ const Openings: FC = () => {
           <div className="Openings__opening-details">{renderOpeningDetails()}</div>
         ) : (
           <div className="Openings__opening-list">
-            <h1 className="Openings__opening-list-heading">Openings</h1>
+            <div className="Openings__opening-list-heading-container">
+              <h1 className="Openings__opening-list-heading">Openings</h1>
+              <Button onClick={() => window.open(OPENINGS_GOOGLE_FORM_LINK)}>Apply</Button>
+            </div>
             {renderOpenings()}
           </div>
         )}


### PR DESCRIPTION
Fixes #1617 

The apply button directs the user to the url:  https://docs.google.com/forms/d/e/1FAIpQLSf4Mk-vxO3Nl193LkCSGPOrrT5uDvA27peH8du7hSnfUsxb0A/viewform

<details>
<summary>PC UI</summary>
<img width="1251" alt="Screen Shot 2021-03-28 at 9 16 37 AM" src="https://user-images.githubusercontent.com/32864116/112739401-c8bb6700-8fa6-11eb-9aff-edc34b98e1d4.png">
<img width="1262" alt="Screen Shot 2021-03-28 at 9 14 03 AM" src="https://user-images.githubusercontent.com/32864116/112739403-c9ec9400-8fa6-11eb-8aea-94c6e4663253.png">
</details>

<details>
<summary>Mobile UI</summary>
<img width="391" alt="Screen Shot 2021-03-28 at 9 16 51 AM" src="https://user-images.githubusercontent.com/32864116/112739406-cc4eee00-8fa6-11eb-8069-371f1fa37183.png">
<img width="390" alt="Screen Shot 2021-03-28 at 9 17 00 AM" src="https://user-images.githubusercontent.com/32864116/112739407-ce18b180-8fa6-11eb-864e-db4a23346988.png">
</details>