### PR TITLE
[#1661] Set table params description to take entire width

### DIFF
--- a/src/components/Table/TableParams/TableParams.scss
+++ b/src/components/Table/TableParams/TableParams.scss
@@ -34,6 +34,10 @@
       font-family: var(--font-family-mono-roboto);
       font-size: 13px;
     }
+
+    &--description {
+      width: 100%;
+    }
   }
 
   &__data-type {


### PR DESCRIPTION
Fixes #1661 

After:
<img width="749" alt="Screen Shot 2021-04-03 at 9 26 37 AM" src="https://user-images.githubusercontent.com/32864116/113464596-60fe9380-9460-11eb-87dc-ec28ba1e0b83.png">
