### PR TITLE
[#1699] Follow disabled button color as Account Manager

### DIFF
--- a/src/components/FormElements/Button/Button.scss
+++ b/src/components/FormElements/Button/Button.scss
@@ -26,9 +26,9 @@
 
       &#{$self}--disabled,
       &#{$self}--disabled:hover {
-        background: var(--color-neutral-300);
-        border-color: var(--color-neutral-300);
-        color: var(--color-neutral-400);
+        background: var(--color-primary-disabled);
+        border-color: var(--color-primary-disabled);
+        color: var(--color-white);
       }
     }
 

--- a/src/styles/_colors.scss
+++ b/src/styles/_colors.scss
@@ -39,8 +39,8 @@
   --color-neutral-800: #424242;
   --color-neutral-900: #212121;
   --color-primary-disabled-fill: #fff9f9;
-  --color-primary-disabled-text: #f4c2c4;
-  --color-primary-disabled: #e6bfc1;
+  --color-primary-disabled-text: #94c9ea;
+  --color-primary-disabled: #b2d7ee;
   --color-primary-hover: #06457a;
   --color-primary-outline-bg: #ffe7e7;
   --color-primary: #042235;


### PR DESCRIPTION
Fixes #1699 

Current:
<img width="403" alt="Screen Shot 2021-04-13 at 8 58 18 PM" src="https://user-images.githubusercontent.com/32864116/114556389-3e0f8300-9c9b-11eb-86e4-6189d55be186.png">

Account Manager:
<img width="395" alt="Screen Shot 2021-04-13 at 8 58 27 PM" src="https://user-images.githubusercontent.com/32864116/114556392-3ea81980-9c9b-11eb-85ee-d840021f8a63.png">
