### PR TITLE
Add caching of github api responses in local storage if not modified

### DIFF
--- a/src/apis/github/index.ts
+++ b/src/apis/github/index.ts
@@ -1,83 +1,37 @@
-import axios from 'axios';
-
 import {BaseIssue, BaseRelease, FetchGithubReleasesParams, Issue, Milestone} from 'types/github';
-import {setLocalStorageItem, getLocalStorageItem, saveETagToLocalStorage} from 'utils/browser';
-import {githubHeaders, validateGitHubApiStatus} from 'utils/requests';
+import {githubGetRequestAbstract} from 'utils/requests';
 
 const BASE_URL = 'https://api.github.com/repos/thenewboston-developers';
 
 export async function getIssuesForRepo(repoPathName: string): Promise<Issue[]> {
-  const eTagKey = `${repoPathName}-issues-etag`;
-  const cachedContentKey = `${repoPathName}-issues`;
-  const eTag = getLocalStorageItem(eTagKey, '');
-  const response = await axios.get<Issue[]>(`${BASE_URL}/${repoPathName}/issues`, {
-    validateStatus: validateGitHubApiStatus,
-    ...githubHeaders(eTag),
+  return githubGetRequestAbstract<Issue[]>({
+    cachedContentKey: `${repoPathName}-issues`,
+    eTagKey: `${repoPathName}-issues-etag`,
+    url: `${BASE_URL}/${repoPathName}/issues`,
   });
-
-  // get cached content if not modified
-  if (response.status === 304) {
-    return getLocalStorageItem(cachedContentKey, []);
-  }
-  saveETagToLocalStorage(eTagKey, response.headers.etag);
-  setLocalStorageItem(cachedContentKey, JSON.stringify(response.data));
-  return response.data;
 }
 
 export async function getAccountManagerReleases(params: FetchGithubReleasesParams): Promise<BaseRelease[]> {
-  const eTagKey = 'account-manager-releases-etag';
-  const cachedContentKey = `account-manager-releases`;
-  const eTag = getLocalStorageItem(eTagKey, '');
-  const response = await axios.get<BaseRelease[]>(`${BASE_URL}/Account-Manager/releases`, {
+  return githubGetRequestAbstract<BaseRelease[]>({
+    cachedContentKey: `account-manager-releases`,
+    eTagKey: 'account-manager-releases-etag',
     params,
-    validateStatus: validateGitHubApiStatus,
-    ...githubHeaders(eTag),
+    url: `${BASE_URL}/Account-Manager/releases`,
   });
-
-  // get cached content if not modified
-  if (response.status === 304) {
-    return getLocalStorageItem(cachedContentKey, []);
-  }
-  saveETagToLocalStorage(eTagKey, response.headers.etag);
-  setLocalStorageItem(cachedContentKey, JSON.stringify(response.data));
-  return response.data;
 }
 
 export async function getMilestones(repoPathName: string): Promise<Milestone[]> {
-  const eTagKey = `${repoPathName}-milestones-etag`;
-  const cachedContentKey = `${repoPathName}-milestones`;
-  const eTag = getLocalStorageItem(eTagKey, '');
-  const response = await axios.get<Milestone[]>(`${BASE_URL}/${repoPathName}/milestones?state=open`, {
-    validateStatus: validateGitHubApiStatus,
-    ...githubHeaders(eTag),
+  return githubGetRequestAbstract<Milestone[]>({
+    cachedContentKey: `${repoPathName}-milestones`,
+    eTagKey: `${repoPathName}-milestones-etag`,
+    url: `${BASE_URL}/${repoPathName}/milestones?state=open`,
   });
-
-  // get cached content if not modified
-  if (response.status === 304) {
-    return getLocalStorageItem(cachedContentKey, []);
-  }
-  saveETagToLocalStorage(eTagKey, response.headers.etag);
-  setLocalStorageItem(cachedContentKey, JSON.stringify(response.data));
-  return response.data;
 }
 
 export async function getIssuesForMilestone(repoPathName: string, milestoneNumber: number): Promise<BaseIssue[]> {
-  const eTagKey = `${repoPathName}-milestonesIssues-${milestoneNumber}-etag`;
-  const cachedContentKey = `${repoPathName}-milestonesIssues-${milestoneNumber}`;
-  const eTag = getLocalStorageItem(eTagKey, '');
-  const response = await axios.get<BaseIssue[]>(
-    `${BASE_URL}/${repoPathName}/issues?milestone=${milestoneNumber}&state=all`,
-    {
-      validateStatus: validateGitHubApiStatus,
-      ...githubHeaders(eTag),
-    },
-  );
-
-  // get cached content if not modified
-  if (response.status === 304) {
-    return getLocalStorageItem(cachedContentKey, []);
-  }
-  saveETagToLocalStorage(eTagKey, response.headers.etag);
-  setLocalStorageItem(cachedContentKey, JSON.stringify(response.data));
-  return response.data;
+  return githubGetRequestAbstract<BaseIssue[]>({
+    cachedContentKey: `${repoPathName}-milestonesIssues-${milestoneNumber}`,
+    eTagKey: `${repoPathName}-milestonesIssues-${milestoneNumber}-etag`,
+    url: `${BASE_URL}/${repoPathName}/issues?milestone=${milestoneNumber}&state=all`,
+  });
 }

--- a/src/apis/github/index.ts
+++ b/src/apis/github/index.ts
@@ -1,29 +1,83 @@
 import axios from 'axios';
 
 import {BaseIssue, BaseRelease, FetchGithubReleasesParams, Issue, Milestone} from 'types/github';
+import {setLocalStorageItem, getLocalStorageItem, saveETagToLocalStorage} from 'utils/browser';
+import {githubHeaders, validateGitHubApiStatus} from 'utils/requests';
 
 const BASE_URL = 'https://api.github.com/repos/thenewboston-developers';
 
 export async function getIssuesForRepo(repoPathName: string): Promise<Issue[]> {
-  const response = await axios.get<Issue[]>(`${BASE_URL}/${repoPathName}/issues`);
+  const eTagKey = `${repoPathName}-issues-etag`;
+  const cachedContentKey = `${repoPathName}-issues`;
+  const eTag = getLocalStorageItem(eTagKey, '');
+  const response = await axios.get<Issue[]>(`${BASE_URL}/${repoPathName}/issues`, {
+    validateStatus: validateGitHubApiStatus,
+    ...githubHeaders(eTag),
+  });
+
+  // get cached content if not modified
+  if (response.status === 304) {
+    return getLocalStorageItem(cachedContentKey, []);
+  }
+  saveETagToLocalStorage(eTagKey, response.headers.etag);
+  setLocalStorageItem(cachedContentKey, JSON.stringify(response.data));
   return response.data;
 }
 
 export async function getAccountManagerReleases(params: FetchGithubReleasesParams): Promise<BaseRelease[]> {
+  const eTagKey = 'account-manager-releases-etag';
+  const cachedContentKey = `account-manager-releases`;
+  const eTag = getLocalStorageItem(eTagKey, '');
   const response = await axios.get<BaseRelease[]>(`${BASE_URL}/Account-Manager/releases`, {
     params,
+    validateStatus: validateGitHubApiStatus,
+    ...githubHeaders(eTag),
   });
+
+  // get cached content if not modified
+  if (response.status === 304) {
+    return getLocalStorageItem(cachedContentKey, []);
+  }
+  saveETagToLocalStorage(eTagKey, response.headers.etag);
+  setLocalStorageItem(cachedContentKey, JSON.stringify(response.data));
   return response.data;
 }
 
 export async function getMilestones(repoPathName: string): Promise<Milestone[]> {
-  const response = await axios.get<Milestone[]>(`${BASE_URL}/${repoPathName}/milestones?state=open`);
+  const eTagKey = `${repoPathName}-milestones-etag`;
+  const cachedContentKey = `${repoPathName}-milestones`;
+  const eTag = getLocalStorageItem(eTagKey, '');
+  const response = await axios.get<Milestone[]>(`${BASE_URL}/${repoPathName}/milestones?state=open`, {
+    validateStatus: validateGitHubApiStatus,
+    ...githubHeaders(eTag),
+  });
+
+  // get cached content if not modified
+  if (response.status === 304) {
+    return getLocalStorageItem(cachedContentKey, []);
+  }
+  saveETagToLocalStorage(eTagKey, response.headers.etag);
+  setLocalStorageItem(cachedContentKey, JSON.stringify(response.data));
   return response.data;
 }
 
 export async function getIssuesForMilestone(repoPathName: string, milestoneNumber: number): Promise<BaseIssue[]> {
+  const eTagKey = `${repoPathName}-milestonesIssues-${milestoneNumber}-etag`;
+  const cachedContentKey = `${repoPathName}-milestonesIssues-${milestoneNumber}`;
+  const eTag = getLocalStorageItem(eTagKey, '');
   const response = await axios.get<BaseIssue[]>(
     `${BASE_URL}/${repoPathName}/issues?milestone=${milestoneNumber}&state=all`,
+    {
+      validateStatus: validateGitHubApiStatus,
+      ...githubHeaders(eTag),
+    },
   );
+
+  // get cached content if not modified
+  if (response.status === 304) {
+    return getLocalStorageItem(cachedContentKey, []);
+  }
+  saveETagToLocalStorage(eTagKey, response.headers.etag);
+  setLocalStorageItem(cachedContentKey, JSON.stringify(response.data));
   return response.data;
 }

--- a/src/utils/browser.ts
+++ b/src/utils/browser.ts
@@ -2,3 +2,15 @@ export const getLocalStorageItem = (key: string, defaultValue: any) => {
   const item = localStorage.getItem(key);
   return item ? JSON.parse(item) : defaultValue;
 };
+
+export const setLocalStorageItem = (key: string, value: string) => {
+  localStorage.setItem(key, value);
+};
+
+export const saveETagToLocalStorage = (key: string, eTag: string) => {
+  // syntax
+  // ETag: W/"<etag_value>"
+  // ETag: "<etag_value>"
+  const parsedETag = eTag.replace('W/', ''); // get <etag_value> from eTag
+  setLocalStorageItem(key, parsedETag);
+};

--- a/src/utils/requests.ts
+++ b/src/utils/requests.ts
@@ -1,5 +1,6 @@
+import axios from 'axios';
 import {APP_ACTIVE_USER} from 'constants/redux';
-import {getLocalStorageItem} from './browser';
+import {getLocalStorageItem, saveETagToLocalStorage, setLocalStorageItem} from './browser';
 
 export function authHeaders() {
   const activeUser = getLocalStorageItem(APP_ACTIVE_USER, null);
@@ -25,6 +26,34 @@ export function githubHeaders(eTag: string) {
       'If-None-Match': `"${eTag}"`, // provide cached etag to see if resource has been updated
     },
   };
+}
+
+export async function githubGetRequestAbstract<R>({
+  eTagKey,
+  cachedContentKey,
+  params = {},
+  url,
+}: {
+  eTagKey: string;
+  cachedContentKey: string;
+  params?: any;
+  url: string;
+}) {
+  const eTag = getLocalStorageItem(eTagKey, '');
+
+  const response = await axios.get<R>(url, {
+    params,
+    validateStatus: validateGitHubApiStatus,
+    ...githubHeaders(eTag),
+  });
+
+  // get cached content if not modified
+  if (response.status === 304) {
+    return getLocalStorageItem(cachedContentKey, []);
+  }
+  saveETagToLocalStorage(eTagKey, response.headers.etag);
+  setLocalStorageItem(cachedContentKey, JSON.stringify(response.data));
+  return response.data;
 }
 
 export function validateGitHubApiStatus(status: number) {

--- a/src/utils/requests.ts
+++ b/src/utils/requests.ts
@@ -18,3 +18,15 @@ export function standardHeaders() {
     },
   };
 }
+
+export function githubHeaders(eTag: string) {
+  return {
+    headers: {
+      'If-None-Match': `"${eTag}"`, // provide cached etag to see if resource has been updated
+    },
+  };
+}
+
+export function validateGitHubApiStatus(status: number) {
+  return (status >= 200 && status <= 299) || status === 304;
+}


### PR DESCRIPTION
Fixes #1791 

1. Save the `ETag` as well as the data returned by the github api responses in local storage
2. Add the saved `ETag` as `If-None-Match` header in request
3. GitHub api will return `304 not modified` status code if `ETag` matches with `If-None-Match`
4. Load the data stored in local storage if `304 not modified`, if not then return data from response

Reference: https://docs.github.com/en/rest/overview/resources-in-the-rest-api#conditional-requests