### PR TITLE
[#1800] Add api for fetching tutorial instructor and add author to videos

### DIFF
--- a/src/apis/tutorials/index.ts
+++ b/src/apis/tutorials/index.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import {allTutorialsFilter} from 'constants/tutorials';
-import {Playlist, PlaylistCategory} from 'types/tutorials';
+import {Playlist, PlaylistCategory, Instructor} from 'types/tutorials';
 import {standardHeaders} from 'utils/requests';
 
 import {PlaylistCategoriesResponse, PlaylistsResponse} from './types';
@@ -35,6 +35,15 @@ export async function getPlaylists(category: string): Promise<Playlist[]> {
 export async function getPlaylist(playlistId: string): Promise<Playlist> {
   const response = await axios.get<Playlist>(
     `${process.env.REACT_APP_BACKEND_API}/playlists/${playlistId}`,
+    standardHeaders(),
+  );
+
+  return response.data;
+}
+
+export async function getInstructor(instructorId: string): Promise<Instructor> {
+  const response = await axios.get<Instructor>(
+    `${process.env.REACT_APP_BACKEND_API}/instructors/${instructorId}`,
     standardHeaders(),
   );
 

--- a/src/containers/Tutorials/PlaylistCard/PlaylistCard.scss
+++ b/src/containers/Tutorials/PlaylistCard/PlaylistCard.scss
@@ -8,10 +8,6 @@
 
   &__author {
     margin-bottom: 4px;
-
-    &-name {
-      color: var(--color-secondary);
-    }
   }
 
   &__bottom {

--- a/src/containers/Tutorials/PlaylistCard/index.tsx
+++ b/src/containers/Tutorials/PlaylistCard/index.tsx
@@ -1,3 +1,4 @@
+import {A} from 'components';
 import React, {FC, useMemo} from 'react';
 import {useHistory, useParams} from 'react-router-dom';
 
@@ -8,13 +9,14 @@ import './PlaylistCard.scss';
 
 interface PlaylistCardProps {
   author: string;
+  authorUrl: string;
   pk: string;
   thumbnail: string;
   title: string;
   video_list: Video[];
 }
 
-const PlaylistCard: FC<PlaylistCardProps> = ({author, pk, title, thumbnail, video_list}) => {
+const PlaylistCard: FC<PlaylistCardProps> = ({author, authorUrl, pk, title, thumbnail, video_list}) => {
   const history = useHistory();
   const {category: playlistCategoryParam} = useParams<TutorialsUrlParams>();
 
@@ -38,7 +40,7 @@ const PlaylistCard: FC<PlaylistCardProps> = ({author, pk, title, thumbnail, vide
       <div className="PlaylistCard__bottom">
         <div className="PlaylistCard__title">{title}</div>
         <div className="PlaylistCard__author">
-          Author: <span className="PlaylistCard__author-name">{author}</span>
+          Author: <A href={authorUrl}>{author}</A>
         </div>
         <div className="PlaylistCard__details">
           <span className="PlaylistCard__details-videos">{video_list.length} videos</span>

--- a/src/containers/Tutorials/Playlists/index.tsx
+++ b/src/containers/Tutorials/Playlists/index.tsx
@@ -1,8 +1,8 @@
 import React, {FC, ReactNode, useCallback, useEffect, useState} from 'react';
 
-import {getPlaylists} from 'apis/tutorials';
+import {getPlaylists, getInstructor} from 'apis/tutorials';
 import {EmptyPage, Loader} from 'components';
-import {Playlist} from 'types/tutorials';
+import {Playlist, Instructor, Source} from 'types/tutorials';
 
 import PlaylistCard from '../PlaylistCard';
 import './Playlists.scss';
@@ -10,10 +10,14 @@ import './Playlists.scss';
 interface PlaylistsParams {
   category: string | null;
 }
+interface PlaylistState {
+  instructor: Instructor;
+  playlist: Playlist;
+}
 
 const Playlists: FC<PlaylistsParams> = ({category}) => {
   const [loading, setLoading] = useState<boolean>(true);
-  const [playlists, setPlaylists] = useState<Playlist[]>([]);
+  const [playlists, setPlaylists] = useState<PlaylistState[]>([]);
   const [errorMessage, setErrorMessage] = useState<string>('');
 
   useEffect(() => {
@@ -22,7 +26,12 @@ const Playlists: FC<PlaylistsParams> = ({category}) => {
         try {
           setLoading(true);
           const fetchedPlaylists = await getPlaylists(category);
-          setPlaylists(fetchedPlaylists);
+          const fetchedPlaylistsWithInstructors = await Promise.all(
+            fetchedPlaylists.map(async (fetchedPlaylist) => {
+              return {instructor: await getInstructor(fetchedPlaylist.instructor), playlist: fetchedPlaylist};
+            }),
+          );
+          setPlaylists(fetchedPlaylistsWithInstructors);
         } catch (error) {
           setErrorMessage(error.message);
         } finally {
@@ -39,9 +48,19 @@ const Playlists: FC<PlaylistsParams> = ({category}) => {
     if (!playlists.length) return <EmptyPage />;
     return (
       <div className="Playlists__grid">
-        {playlists.map(({author, pk, title, thumbnail, video_list}) => (
-          <PlaylistCard author={author} key={pk} pk={pk} thumbnail={thumbnail} title={title} video_list={video_list} />
-        ))}
+        {playlists.map(({instructor, playlist}) => {
+          return (
+            <PlaylistCard
+              author={instructor.name}
+              authorUrl={playlist.playlist_type === Source.youtube ? instructor.youtube_url : instructor.vimeo_url}
+              key={playlist.pk}
+              pk={playlist.pk}
+              thumbnail={playlist.thumbnail}
+              title={playlist.title}
+              video_list={playlist.video_list}
+            />
+          );
+        })}
       </div>
     );
   }, [errorMessage, playlists]);

--- a/src/containers/Tutorials/WatchPlaylist/WatchPlaylist.scss
+++ b/src/containers/Tutorials/WatchPlaylist/WatchPlaylist.scss
@@ -124,10 +124,6 @@
     &-author {
       font-size: 14px;
       margin-bottom: 0px;
-
-      &-name {
-        color: var(--color-secondary);
-      }
     }
 
     &-date {

--- a/src/containers/Tutorials/WatchPlaylist/index.tsx
+++ b/src/containers/Tutorials/WatchPlaylist/index.tsx
@@ -3,9 +3,9 @@ import clsx from 'clsx';
 import format from 'date-fns/format';
 import parseISO from 'date-fns/parseISO';
 
-import {getPlaylist} from 'apis/tutorials';
-import {EmptyPage, Loader, VideoPlayer} from 'components';
-import {Playlist, Source, TimeFormat, Video} from 'types/tutorials';
+import {getPlaylist, getInstructor} from 'apis/tutorials';
+import {A, EmptyPage, Loader, VideoPlayer} from 'components';
+import {Instructor, Playlist, Source, TimeFormat, Video} from 'types/tutorials';
 import {getFormattedTime} from 'utils/time';
 
 import './WatchPlaylist.scss';
@@ -18,6 +18,7 @@ interface WatchPlaylistProps {
 const WatchPlaylist: FC<WatchPlaylistProps> = ({playlistId}) => {
   const [loading, setLoading] = useState<boolean>(true);
   const [playlist, setPlaylist] = useState<Playlist | null>(null);
+  const [instructor, setInstructor] = useState<Instructor | null>(null);
   const [currentVideo, setCurrentVideo] = useState<Video | null>(null);
   const [errorMessage, setErrorMessage] = useState<string>('');
 
@@ -26,7 +27,9 @@ const WatchPlaylist: FC<WatchPlaylistProps> = ({playlistId}) => {
       try {
         setLoading(true);
         const playlistResponse = await getPlaylist(playlistId);
+        const instructorResponse = await getInstructor(playlistResponse.instructor);
         setPlaylist(playlistResponse);
+        setInstructor(instructorResponse);
         if (playlistResponse.video_list.length) {
           setCurrentVideo(playlistResponse.video_list[0]);
         }
@@ -85,7 +88,7 @@ const WatchPlaylist: FC<WatchPlaylistProps> = ({playlistId}) => {
             <div className="WatchPlaylist__list-video-details">
               <div className="WatchPlaylist__list-video-top">{video.title}</div>
               <div className="WatchPlaylist__list-video-bottom">
-                <span className="WatchPlaylist__list-video-author">{video.author}</span>
+                <span className="WatchPlaylist__list-video-author">{instructor?.name}</span>
                 <span className="WatchPlaylist__list-video-duration">
                   {getFormattedTime(video.duration_seconds, TimeFormat.digital)}
                 </span>
@@ -121,7 +124,11 @@ const WatchPlaylist: FC<WatchPlaylistProps> = ({playlistId}) => {
           </div>
           <div className="WatchPlaylist__video-author">
             {playlist.playlist_type === Source.youtube ? 'Youtube' : 'Vimeo'} Channel:{' '}
-            <span className="WatchPlaylist__video-author-name">{currentVideo.author}</span>
+            {instructor && (
+              <A href={playlist.playlist_type === Source.youtube ? instructor.youtube_url : instructor.vimeo_url}>
+                {instructor.name}
+              </A>
+            )}
           </div>
         </div>
       </div>

--- a/src/types/tutorials.ts
+++ b/src/types/tutorials.ts
@@ -19,7 +19,6 @@ export interface PlaylistCategory extends CreatedModified {
 }
 
 export interface Video extends CreatedModified {
-  author: string;
   categories: string[];
   description: string;
   duration_seconds: number;
@@ -35,9 +34,9 @@ export interface Video extends CreatedModified {
 }
 
 export interface Playlist extends CreatedModified {
-  author: string;
   categories: string[];
   description: string;
+  instructor: string;
   language: string;
   pk: string;
   playlist_id: string;
@@ -51,4 +50,13 @@ export interface Playlist extends CreatedModified {
 export interface TutorialsUrlParams {
   category: string;
   playlistId: string;
+}
+
+export interface Instructor {
+  pk: string;
+  name: string;
+  youtube_url: string;
+  vimeo_url: string;
+  created_date: string;
+  modified_date: string;
 }


### PR DESCRIPTION
Fixes #1800 

Added api calls to fetch instructor, also made the author name clickable to re-direct user to their channel.

Before:

<img width="881" alt="Screen Shot 2021-05-16 at 4 16 36 PM" src="https://user-images.githubusercontent.com/32864116/118391579-81c52600-b667-11eb-9d32-a2d4b6c86742.png">
<img width="1081" alt="Screen Shot 2021-05-16 at 4 54 08 PM" src="https://user-images.githubusercontent.com/32864116/118391582-8558ad00-b667-11eb-9f02-24e5ef0fffc3.png">


After:

<img width="1090" alt="Screen Shot 2021-05-16 at 4 54 04 PM" src="https://user-images.githubusercontent.com/32864116/118391583-88539d80-b667-11eb-9e79-0440dd5a8baf.png">
<img width="1088" alt="Screen Shot 2021-05-16 at 4 54 20 PM" src="https://user-images.githubusercontent.com/32864116/118391584-8a1d6100-b667-11eb-91d2-53c7160f32e0.png">
