### PR TITLE
Add onClick function for Link in FaqDropDownCard | Fixes #1848

### DIFF
--- a/src/components/FaqDropdownCard/index.tsx
+++ b/src/components/FaqDropdownCard/index.tsx
@@ -29,7 +29,7 @@ const FaqDropdownCard: FC<Props> = ({answer, className, id, question}) => {
       <div className="FaqDropdownCard__anchor" id={id} />
       <div className="FaqDropdownCard__dropdown-container">
         <div className="FaqDropdownCard__left-container">
-          <Link className="FaqDropdownCard__question" to={`${pathname}#${id}`}>
+          <Link className="FaqDropdownCard__question" to={`${pathname}#${id}`} onClick={toggleExpanded}>
             {question}
           </Link>
           <HashLink className="FaqDropdownCard__HashLink" id={id} />


### PR DESCRIPTION
This PR fixes the issue that I have raised regarding the FAQ Question toggle issue. Now, the link is clickable, and also the drop-down is togglable by clicking both on the Link as well as on the icon to the right.

Please lemme know if there are any issues.