### PR TITLE
Removed the x-scroll bar

### DIFF
--- a/src/styles/_core.scss
+++ b/src/styles/_core.scss
@@ -16,6 +16,11 @@ body {
   @extend %body1;
 }
 
+body{
+  width: 100%;
+  height: 100%;
+  overflow-x: hidden;
+}
 #popover-root {
   position: fixed;
   top: 0;


### PR DESCRIPTION
Removed the x-scroll bar in the downloads page.
Account: `daa957ba0a1b63d5d724bc6e11553dbd6981d7d5da4a4a3daf4fd79c67058c8f`