### PR TITLE
100vw fix

### DIFF
--- a/src/components/Container/Container.scss
+++ b/src/components/Container/Container.scss
@@ -1,0 +1,4 @@
+.Container {
+  margin-left: auto;
+  margin-right: auto;
+}

--- a/src/components/Container/index.tsx
+++ b/src/components/Container/index.tsx
@@ -1,0 +1,42 @@
+/* eslint-disable react/jsx-props-no-spreading */
+
+import React, {FC, useMemo} from 'react';
+import clsx from 'clsx';
+
+import './Container.scss';
+
+type ContainerElement = 'div' | 'header' | 'main';
+
+interface ContainerProps {
+  className?: string;
+  element?: ContainerElement;
+  dataTestId?: string;
+  maxWidth?: number;
+}
+
+const Container: FC<ContainerProps> = ({children, className, dataTestId, element = 'div', maxWidth = 1366}) => {
+  const props = useMemo(
+    () => ({
+      className: clsx('Container', className),
+      'data-testid': dataTestId,
+      style: {
+        maxWidth,
+      },
+    }),
+    [className, dataTestId, maxWidth],
+  );
+
+  switch (element) {
+    case 'header': {
+      return <header {...props}>{children}</header>;
+    }
+    case 'main': {
+      return <main {...props}>{children}</main>;
+    }
+    default: {
+      return <div {...props}>{children}</div>;
+    }
+  }
+};
+
+export default Container;

--- a/src/components/DashboardLayout/index.tsx
+++ b/src/components/DashboardLayout/index.tsx
@@ -1,6 +1,6 @@
 import React, {FC, ReactNode} from 'react';
 
-import {BreadcrumbMenu, PageTitle} from 'components';
+import {BreadcrumbMenu, Container, PageTitle} from 'components';
 import './DashboardLayout.scss';
 
 export interface DashboardLayoutProps {
@@ -14,7 +14,7 @@ const DashboardLayout: FC<DashboardLayoutProps> = ({children, menuItems, pageNam
   return (
     <>
       <PageTitle title={`${sectionName}`} />
-      <div className="DashboardLayout">
+      <Container className="DashboardLayout">
         <BreadcrumbMenu
           className="DashboardLayout__BreadcrumbMenu"
           menuItems={menuItems}
@@ -27,7 +27,7 @@ const DashboardLayout: FC<DashboardLayoutProps> = ({children, menuItems, pageNam
         <div className="DashboardLayout__main-content" data-testid="DashboardLayout__main-content_test">
           {children}
         </div>
-      </div>
+      </Container>
     </>
   );
 };

--- a/src/components/Layout/Layout.scss
+++ b/src/components/Layout/Layout.scss
@@ -11,15 +11,6 @@ $footer-height: 348px;
     min-height: calc(100vh - #{$top-nav-height + $footer-height});
   }
 
-  &__content,
-  &__Footer {
-    @media (min-width: 1366px) {
-      margin-left: auto;
-      margin-right: auto;
-      max-width: 1366px;
-    }
-  }
-
   &__footer-wrapper {
     background: var(--color-primary);
     padding: 60px 60px 120px;

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -1,8 +1,7 @@
 import React, {FC, ReactNode, useEffect} from 'react';
 import {useLocation} from 'react-router-dom';
-import clsx from 'clsx';
 
-import {Footer, GoToTop} from 'components';
+import {Container, Footer, GoToTop} from 'components';
 import TopNav from 'containers/TopNav';
 import './Layout.scss';
 
@@ -12,8 +11,6 @@ export interface LayoutProps {
 
 const Layout: FC<LayoutProps> = ({children}) => {
   const {hash, pathname} = useLocation();
-  const isHomepage = pathname === '/';
-  const isProfilePage = pathname.includes('/profile');
 
   useEffect(() => {
     if (!hash) {
@@ -32,15 +29,14 @@ const Layout: FC<LayoutProps> = ({children}) => {
       <div className="Layout__top-nav-wrapper">
         <TopNav className="Layout__TopNav" />
       </div>
-      <div
-        className={clsx({Layout__content: !(isHomepage || isProfilePage), Layout__home: isHomepage})}
-        data-testid="Layout__content"
-      >
+      <div className="Layout__content" data-testid="Layout__content">
         {children}
       </div>
       <div className="Layout__footer-wrapper">
         <GoToTop />
-        <Footer className="Layout__Footer" />
+        <Container className="Layout__Footer">
+          <Footer />
+        </Container>
       </div>
     </div>
   );

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -3,6 +3,7 @@ import AuthContainer from './AuthContainer';
 import Avatar from './Avatar';
 import BreadcrumbMenu from './BreadcrumbMenu';
 import {CodeSnippet, RequestResponseSnippet, SnippetLang} from './CodeSnippet';
+import Container from './Container';
 import ContributorTasks from './ContributorTasks';
 import CopyableAccountNumber from './CopyableAccountNumber';
 import DashboardLayout from './DashboardLayout';
@@ -58,6 +59,7 @@ export {
   Button,
   CalloutType,
   CodeSnippet,
+  Container,
   ContributorTasks,
   CopyableAccountNumber,
   DashboardLayout,

--- a/src/containers/Assets/index.tsx
+++ b/src/containers/Assets/index.tsx
@@ -3,7 +3,7 @@ import clsx from 'clsx';
 import {Icon, IconType} from '@thenewboston/ui';
 
 import {Asset} from 'types/assets';
-import {A, PageTitle} from 'components';
+import {A, Container, PageTitle} from 'components';
 import {socialMediaUrls} from 'utils/social-media';
 import TnbLogo from 'assets/images/TNB-Logo.png';
 import TnbLogoAndWordmark from 'assets/images/TNB-LogoAndWordmark.png';
@@ -57,11 +57,11 @@ const Assets: FC = () => {
   return (
     <>
       <PageTitle title="Assets" />
-      <div className="Assets">
+      <Container className="Assets">
         <h1 className="Assets__heading">Download thenewboston assets</h1>
         <h2 className="Assets__subtext">All assets of thenewboston at one place for you to download.</h2>
         <div className="Assets__cards-container">{assets.map((asset: Asset) => renderCard(asset))}</div>
-      </div>
+      </Container>
     </>
   );
 };

--- a/src/containers/CreateAccount/index.tsx
+++ b/src/containers/CreateAccount/index.tsx
@@ -1,7 +1,7 @@
 import React, {FC, ReactNode, useState} from 'react';
 
 import * as api from 'apis/users';
-import {AuthContainer} from 'components';
+import {AuthContainer, Container} from 'components';
 import {Form, FormButton, FormInput} from 'components/FormComponents';
 import {formatAPIError} from 'utils/errors';
 import yup from 'utils/yup';
@@ -102,7 +102,7 @@ const CreateAccount: FC<ComponentProps> = ({disabled = false}) => {
   });
 
   return (
-    <div className="CreateAccount">
+    <Container className="CreateAccount">
       {disabled ? (
         renderDisabledMessage()
       ) : (
@@ -110,7 +110,7 @@ const CreateAccount: FC<ComponentProps> = ({disabled = false}) => {
           {renderAuthContainerContent()}
         </AuthContainer>
       )}
-    </div>
+    </Container>
   );
 };
 

--- a/src/containers/Donate/Donate.scss
+++ b/src/containers/Donate/Donate.scss
@@ -14,8 +14,8 @@
     margin-left: 6px;
     margin-right: 6px;
     margin-top: 12px;
-    max-width: 357px;
     padding: 18px;
+    width: 357px;
   }
 
   &__cards-container {

--- a/src/containers/Donate/index.tsx
+++ b/src/containers/Donate/index.tsx
@@ -1,6 +1,6 @@
 import React, {FC, memo, ReactNode} from 'react';
 import clsx from 'clsx';
-import {PageTitle} from 'components';
+import {Container, PageTitle} from 'components';
 
 import BitcoinLogo from 'assets/svgs/bitcoin.svg';
 import EthereumLogo from 'assets/svgs/ethereum.svg';
@@ -54,7 +54,7 @@ const Social: FC = () => {
   return (
     <>
       <PageTitle title="Donate" />
-      <div className="Donate">
+      <Container className="Donate">
         <h1 className="Donate__heading">Donate to thenewboston</h1>
         <h2 className="Donate__subtext">
           All donations will go to thenewboston to help fund the team to continue to develop the community and create
@@ -65,7 +65,7 @@ const Social: FC = () => {
           {renderCard(Crypto.bitcoin)}
           {renderCard(Crypto.ethereum)}
         </div>
-      </div>
+      </Container>
     </>
   );
 };

--- a/src/containers/Download/Download.scss
+++ b/src/containers/Download/Download.scss
@@ -3,10 +3,6 @@
 $top-nav-height: 60px;
 
 .Download {
-  display: flex;
-  flex-direction: column;
-  position: relative;
-
   @media (max-width: 480px) {
     margin: 5% auto;
     padding: 0;
@@ -26,16 +22,13 @@ $top-nav-height: 60px;
     background-color: var(--color-gray-050);
     display: flex;
     justify-content: center;
-    width: 100vw;
   }
 
   &__main-content {
     align-items: center;
     display: flex;
     flex-direction: column;
-    max-width: 1366px;
     padding: 48px 0;
-    width: 100%;
   }
 
   &__title {
@@ -127,22 +120,6 @@ $top-nav-height: 60px;
     width: 100%;
   }
 
-  &__latest-version {
-    padding: 18px 12px;
-    position: absolute;
-    right: 0;
-    text-align: end;
-    top: 0;
-
-    @media (max-width: 768px) {
-      margin-top: 4%;
-      padding: 2% 0;
-
-      position: initial;
-      text-align: center;
-    }
-  }
-
   .instruction-container {
     width: 100%;
 
@@ -170,7 +147,9 @@ $top-nav-height: 60px;
   }
 
   &__release-notes {
-    position: relative;
+    @media (max-width: 1366px) {
+      padding: 0 24px;
+    }
   }
 
   &__release-notes-anchor {

--- a/src/containers/Download/index.tsx
+++ b/src/containers/Download/index.tsx
@@ -1,7 +1,7 @@
 import React, {FC, ReactNode, useCallback, useEffect, useMemo, useState} from 'react';
 import {Link} from 'react-router-dom';
 
-import {A, Button, CodeSnippet, Loader, PageTitle} from 'components';
+import {A, Button, CodeSnippet, Container, Loader, PageTitle} from 'components';
 import {Release} from 'types/github';
 import {fetchGithubReleases} from 'utils/github';
 import {displayErrorToast} from 'utils/toast';
@@ -182,7 +182,7 @@ const Download: FC = () => {
         ) : (
           <>
             <div className="Download__main-background">
-              <div className="Download__main-content">
+              <Container className="Download__main-content">
                 <div className="Download__title">Download Wallet</div>
                 <div className="Download__subtitle">Send and receive coins with our free and secure wallet</div>
                 <div className="Download__latest-release">LATEST RELEASE 1.0.0-alpha.{latestReleaseNumber}</div>
@@ -202,12 +202,12 @@ const Download: FC = () => {
                   {renderDownloadCard(Os.Mac)}
                   {renderDownloadCard(Os.Linux)}
                 </div>
-              </div>
+              </Container>
             </div>
-            <div className="Download__release-notes">
+            <Container className="Download__release-notes">
               <div className="Download__release-notes-anchor" id="release-notes" />
               <ReleaseNotes />
-            </div>
+            </Container>
           </>
         )}
       </div>

--- a/src/containers/Faq/Faq.scss
+++ b/src/containers/Faq/Faq.scss
@@ -3,7 +3,6 @@
 
 .Faq {
   $self: &;
-  margin: 0 auto;
   min-height: 700px;
   padding-bottom: 120px;
 

--- a/src/containers/Faq/index.tsx
+++ b/src/containers/Faq/index.tsx
@@ -1,7 +1,7 @@
 import React, {FC, useCallback, useEffect, useMemo, useState} from 'react';
 import {useHistory, useParams} from 'react-router-dom';
 
-import {Button, FaqDropdownCard, Input, PageTitle} from 'components';
+import {Button, Container, FaqDropdownCard, Input, PageTitle} from 'components';
 import {useWindowDimensions} from 'hooks';
 import {FaqContent, faqFilters, FaqFilterType, faqQuestionsAndAnswers} from 'types/faq';
 
@@ -98,7 +98,7 @@ const Faq: FC = () => {
   return (
     <>
       <PageTitle title="FAQ's" />
-      <div className="Faq">
+      <Container className="Faq">
         <div className="Faq__title-container">
           <div className="Faq__title">Frequently Asked Questions</div>
           <div className="Faq__subtitle">
@@ -137,7 +137,7 @@ const Faq: FC = () => {
           </div>
         </div>
         <Feedback />
-      </div>
+      </Container>
     </>
   );
 };

--- a/src/containers/Guidelines/Guidelines.scss
+++ b/src/containers/Guidelines/Guidelines.scss
@@ -1,10 +1,9 @@
 .Guidelines {
-  margin-left: auto;
-  margin-right: auto;
   margin-top: 60px;
-  max-width: 720px;
   min-height: 700px;
   padding-bottom: 120px;
+  padding-left: 32px;
+  padding-right: 32px;
 
   &__list {
     li {

--- a/src/containers/Guidelines/index.tsx
+++ b/src/containers/Guidelines/index.tsx
@@ -1,6 +1,6 @@
 import React, {FC} from 'react';
 
-import {PageTitle} from 'components';
+import {Container, PageTitle} from 'components';
 
 import './Guidelines.scss';
 
@@ -8,7 +8,7 @@ const Guidelines: FC = () => {
   return (
     <>
       <PageTitle title="Community Guidelines" />
-      <div className="Guidelines">
+      <Container className="Guidelines" maxWidth={720}>
         <h1 className="Guidelines__title">Community Guidelines</h1>
         <h2 className="Guidelines__subtitle">Overview</h2>
         <p>We at thenewboston have two goals:</p>
@@ -64,7 +64,7 @@ const Guidelines: FC = () => {
             member.
           </li>
         </ol>
-      </div>
+      </Container>
     </>
   );
 };

--- a/src/containers/Openings/index.tsx
+++ b/src/containers/Openings/index.tsx
@@ -1,7 +1,7 @@
 import React, {FC, ReactNode, useCallback, useEffect, useMemo, useState} from 'react';
 import {useHistory, useParams} from 'react-router-dom';
 
-import {BreadcrumbMenu, EmptyPage, FlatNavLinks, PageTitle} from 'components';
+import {BreadcrumbMenu, Container, EmptyPage, FlatNavLinks, PageTitle} from 'components';
 import {getOpenings} from 'utils/data';
 import {NavOption} from 'types/option';
 import {OpeningCategory, OpeningsUrlParams} from 'types/openings';
@@ -83,7 +83,7 @@ const Openings: FC = () => {
   return (
     <>
       <PageTitle ogDescription={`${categoryParam} Openings`} title={`${categoryParam} Openings`} />
-      <div className="Openings">
+      <Container className="Openings">
         <BreadcrumbMenu
           className="Openings__BreadcrumbMenu"
           menuItems={renderCategoryFilter()}
@@ -101,7 +101,7 @@ const Openings: FC = () => {
             {renderOpenings()}
           </div>
         )}
-      </div>
+      </Container>
     </>
   );
 };

--- a/src/containers/Progress/index.tsx
+++ b/src/containers/Progress/index.tsx
@@ -2,7 +2,7 @@ import React, {FC, useEffect, useState} from 'react';
 import subDays from 'date-fns/subDays';
 
 import * as githubApi from 'apis/github';
-import {Loader, PageTitle} from 'components';
+import {Container, Loader, PageTitle} from 'components';
 import {BaseIssue, Milestone} from 'types/github';
 import {TeamName} from 'types/teams';
 import {teamMilestoneDetails} from './constants';
@@ -152,7 +152,7 @@ const Progress: FC = () => {
   return (
     <>
       <PageTitle ogDescription="Weekly Progress" title="Weekly Progress" />
-      <div className="Progress">
+      <Container className="Progress">
         <ProgressHeader
           goal={generalMilestone.milestone.description}
           startDate={startDate}
@@ -223,7 +223,7 @@ const Progress: FC = () => {
             repoNames={teamMilestoneDetails[TeamName.marketing].repositoryNames}
           />
         )}
-      </div>
+      </Container>
     </>
   );
 };

--- a/src/containers/Projects/ProjectRulesAndGuide/index.tsx
+++ b/src/containers/Projects/ProjectRulesAndGuide/index.tsx
@@ -1,6 +1,7 @@
 import React, {FC} from 'react';
 import {Link} from 'react-scroll';
 
+import {Container} from 'components';
 import {NAVBAR_HEIGHT} from 'constants/offsets';
 
 import HowProposalsWork from './HowProposalsWork';
@@ -8,7 +9,6 @@ import Rules from './Rules';
 import ProposalSubmissionProcess from './ProposalSubmissionProcess';
 import MilestonesAndPayouts from './MilestonesAndPayouts';
 import './ProjectRules.scss';
-import {Container} from '../../../components';
 
 interface Section {
   id: string;

--- a/src/containers/Projects/ProjectRulesAndGuide/index.tsx
+++ b/src/containers/Projects/ProjectRulesAndGuide/index.tsx
@@ -8,6 +8,7 @@ import Rules from './Rules';
 import ProposalSubmissionProcess from './ProposalSubmissionProcess';
 import MilestonesAndPayouts from './MilestonesAndPayouts';
 import './ProjectRules.scss';
+import {Container} from '../../../components';
 
 interface Section {
   id: string;
@@ -42,7 +43,7 @@ const ProjectRules: FC = () => {
         <h1 className="ProjectRules__banner-headline">Project Rules and Guidelines</h1>
         <p className="ProjectRules__banner-text">The detailed guidelines about how the projects works. </p>
       </header>
-      <main className="ProjectRules__main">
+      <Container className="ProjectRules__main" element="main">
         <aside className="ProjectRules__sidebar">
           {SECTIONS.map((section) => (
             <Link
@@ -68,7 +69,7 @@ const ProjectRules: FC = () => {
           <hr className="ProjectRules__divider" />
           <MilestonesAndPayouts />
         </section>
-      </main>
+      </Container>
     </div>
   );
 };

--- a/src/containers/Projects/Projects.scss
+++ b/src/containers/Projects/Projects.scss
@@ -1,6 +1,4 @@
 .Projects {
-  overflow-x: hidden;
-
   &__loading-container {
     align-items: center;
     display: flex;

--- a/src/containers/Projects/index.tsx
+++ b/src/containers/Projects/index.tsx
@@ -3,7 +3,7 @@ import {Redirect, useParams} from 'react-router-dom';
 
 import {api as projectsApi} from 'apis/projects';
 import {Project} from 'types/projects';
-import {Loader, PageTitle} from 'components';
+import {Container, Loader, PageTitle} from 'components';
 import ListOfProjects from './ListOfProjects';
 import ProjectsHero from './ProjectsHero';
 import ProjectDetails from './ProjectDetails';
@@ -54,10 +54,10 @@ const Projects: FC = () => {
           ogDescription="Earn coins by building apps, games, tools, and other software for thenewboston network."
           title="Projects"
         />
-        <div className="Projects">
+        <Container className="Projects">
           <ProjectsHero />
           <ListOfProjects projects={projects} />
-        </div>
+        </Container>
       </>
     );
   }
@@ -66,7 +66,9 @@ const Projects: FC = () => {
     return (
       <>
         <PageTitle ogDescription={selectedProject.description} title={selectedProject.title} />
-        <ProjectDetails project={selectedProject} />
+        <Container>
+          <ProjectDetails project={selectedProject} />
+        </Container>
       </>
     );
   }

--- a/src/containers/Social/index.tsx
+++ b/src/containers/Social/index.tsx
@@ -1,6 +1,6 @@
 import React, {FC, ReactNode} from 'react';
 
-import {MarketingCard, PageTitle} from 'components';
+import {Container, MarketingCard, PageTitle} from 'components';
 import {SocialMedia} from 'types/social-media';
 
 import './Social.scss';
@@ -23,13 +23,13 @@ const Social: FC = () => {
   return (
     <>
       <PageTitle title="Join the Community!" />
-      <div className="Social">
+      <Container className="Social">
         <h1 className="Social__heading">Be a part of the community</h1>
         <h2 className="Social__subtext">
           Explore ways to get involved, earn coins and stay up-to-date with the latest announcements and events.
         </h2>
         {renderSocialCards()}
-      </div>
+      </Container>
     </>
   );
 };

--- a/src/containers/Tasks/index.tsx
+++ b/src/containers/Tasks/index.tsx
@@ -5,7 +5,16 @@ import parseISO from 'date-fns/parseISO';
 import intersection from 'lodash/intersection';
 import {Icon, IconType} from '@thenewboston/ui';
 
-import {BreadcrumbMenu, DropdownInput, EmptyPage, FlatNavLinks, LabelFilter, Loader, PageTitle} from 'components';
+import {
+  BreadcrumbMenu,
+  Container,
+  DropdownInput,
+  EmptyPage,
+  FlatNavLinks,
+  LabelFilter,
+  Loader,
+  PageTitle,
+} from 'components';
 import {fetchGithubIssues} from 'utils/github';
 import {GenericVoidFunction} from 'types/generic';
 import {Issue, Repository, RepositoryUrlParams} from 'types/github';
@@ -132,7 +141,7 @@ const Tasks: FC = () => {
   return (
     <>
       <PageTitle ogDescription={`${repositoryFilter} Tasks`} title={`${repositoryFilter} Tasks`} />
-      <div className="Tasks">
+      <Container className="Tasks">
         <BreadcrumbMenu
           className="Tasks__BreadcrumbMenu"
           menuItems={renderFilters()}
@@ -163,7 +172,7 @@ const Tasks: FC = () => {
             renderTasks()
           )}
         </div>
-      </div>
+      </Container>
     </>
   );
 };

--- a/src/containers/Teams/index.tsx
+++ b/src/containers/Teams/index.tsx
@@ -2,7 +2,7 @@ import React, {FC, ReactNode, useCallback, useEffect, useState} from 'react';
 import {Link, useHistory, useParams} from 'react-router-dom';
 import {Icon, IconType} from '@thenewboston/ui';
 
-import {A, BreadcrumbMenu, EmptyPage, FlatNavLinks, PageTitle} from 'components';
+import {A, BreadcrumbMenu, Container, EmptyPage, FlatNavLinks, PageTitle} from 'components';
 import {TEAMS} from 'constants/teams';
 import useQueryParams from 'hooks/useQueryParams';
 import {NavigationItem} from 'types/navigation';
@@ -195,7 +195,7 @@ const Teams: FC = () => {
         ogDescription={teamFilter === TeamName.all ? 'All Teams' : `${teamFilter} Team`}
         title={teamFilter === TeamName.all ? 'All Teams' : `${teamFilter} Team`}
       />
-      <div className="Teams">
+      <Container className="Teams">
         <BreadcrumbMenu
           className="Teams__BreadcrumbMenu"
           menuItems={renderTeamFilter()}
@@ -214,7 +214,7 @@ const Teams: FC = () => {
             </>
           )}
         </section>
-      </div>
+      </Container>
     </>
   );
 };

--- a/src/containers/TopNav/TopNav.scss
+++ b/src/containers/TopNav/TopNav.scss
@@ -21,12 +21,6 @@ $top-nav-height: 60px;
   height: $top-nav-height;
   justify-content: space-between;
 
-  @media (min-width: 1366px) {
-    margin-left: auto;
-    margin-right: auto;
-    max-width: 1366px;
-  }
-
   &__left {
     align-items: center;
     display: flex;

--- a/src/containers/TopNav/index.tsx
+++ b/src/containers/TopNav/index.tsx
@@ -2,6 +2,7 @@ import React, {FC, ReactNode, useEffect, useState} from 'react';
 import {useLocation} from 'react-router-dom';
 import clsx from 'clsx';
 
+import {Container} from 'components';
 import {useBooleanState, useWindowDimensions} from 'hooks';
 import TopNavDesktopItems from './TopNavDesktopItems';
 import TopNavLogo from './TopNavLogo';
@@ -43,12 +44,12 @@ const TopNav: FC<ComponentProps> = ({className}) => {
 
   return (
     <div className={clsx('TopNav__wrapper', {'TopNav__wrapper--mobile-menu-open': mobileMenuIsOpen})}>
-      <header className={clsx('TopNav', className)}>
+      <Container className={clsx('TopNav', className)} element="header">
         <div className="TopNav__left">
           <TopNavLogo />
         </div>
         {renderRightItems()}
-      </header>
+      </Container>
     </div>
   );
 };

--- a/src/containers/Tutorials/index.tsx
+++ b/src/containers/Tutorials/index.tsx
@@ -2,7 +2,7 @@ import React, {FC, ReactNode, useCallback, useEffect, useState} from 'react';
 import {useHistory, useParams} from 'react-router-dom';
 
 import {getPlaylistCategories} from 'apis/tutorials';
-import {BreadcrumbMenu, FlatNavLinks, Loader, PageTitle} from 'components';
+import {BreadcrumbMenu, Container, FlatNavLinks, Loader, PageTitle} from 'components';
 import {allTutorialsFilter} from 'constants/tutorials';
 import {NavOption} from 'types/option';
 import {PlaylistCategory, TutorialsUrlParams} from 'types/tutorials';
@@ -77,7 +77,7 @@ const Tutorials: FC = () => {
   return (
     <>
       <PageTitle title="Tutorials" />
-      <div className="Tutorials">
+      <Container className="Tutorials">
         <BreadcrumbMenu
           className="Tutorials__BreadcrumbMenu"
           menuItems={renderCategoryFilter()}
@@ -92,7 +92,7 @@ const Tutorials: FC = () => {
             <Playlists category={playlistCategoryFilter} />
           )}
         </div>
-      </div>
+      </Container>
     </>
   );
 };


### PR DESCRIPTION
Our new designs will have sections where the background will have 100vw, but the way that our code was structured prevented things from being 100vw, since we dictated a `max-width` in the `Layout` component (which encompasses all components).

This forced us to come up with hacky solutions such as explicitely putting styling to override this.

Because I see this a common occurrence as design gets updated, I decided that it is no longer appropriate for our app to have a `max-width` automatically enforced to all components. Rather, I have created a `Container` component that naturally works like a Container (ex: https://material-ui.com/components/container/)

I have gone through every single page on our website to make sure that it incorporates it, and I have also applied changes where it applies.

closes #1890 