### PR TITLE
[#1911] [#1883] Fix overflow-x and no space in downloads page

### DIFF
--- a/src/containers/Download/Download.scss
+++ b/src/containers/Download/Download.scss
@@ -72,12 +72,20 @@ $top-nav-height: 60px;
     grid-row-gap: 24px;
     grid-template-columns: repeat(3, minmax(0, 1fr));
 
+    @media (max-width: 1366px) {
+      padding: 0 24px;
+    }
+
     @media (max-width: 992px) {
       grid-column-gap: 16px;
     }
 
     @media (max-width: 768px) {
       grid-template-columns: 1fr;
+    }
+
+    @media (max-width: 414px) {
+      padding: 0;
     }
   }
 
@@ -96,7 +104,6 @@ $top-nav-height: 60px;
     }
 
     @media (max-width: 768px) {
-      margin: 0 36px;
       padding: 48px 32px;
     }
   }


### PR DESCRIPTION
Fixes #1911 
Fixes #1883 

No overflow x in mobile view
<img width="427" alt="Screen Shot 2021-07-01 at 7 08 56 PM" src="https://user-images.githubusercontent.com/32864116/124114982-d4d02c80-da9f-11eb-8810-f9fc75fc8df6.png">


padding in larger viewports
<img width="1318" alt="Screen Shot 2021-07-01 at 7 08 48 PM" src="https://user-images.githubusercontent.com/32864116/124114966-d00b7880-da9f-11eb-9db8-afba864752cb.png">
