### PR TITLE
Fix ProgressiveImage truncated issue

### DIFF
--- a/src/components/ProgressiveImage/ProgressiveImage.scss
+++ b/src/components/ProgressiveImage/ProgressiveImage.scss
@@ -12,7 +12,7 @@
     @extend %centered-position;
     filter: blur(20px);
     height: 100%;
-    object-fit: cover;
+    object-fit: contain;
     width: 100%;
 
     &--loaded {
@@ -24,7 +24,7 @@
     @extend %centered-position;
     filter: blur(20px);
     height: 100%;
-    object-fit: cover;
+    object-fit: contain;
     transition: filter 0.75s linear;
     width: 100%;
 


### PR DESCRIPTION
Before:

<img width="714" alt="Screen Shot 2021-07-03 at 3 28 22 PM" src="https://user-images.githubusercontent.com/32864116/124346784-5a281e00-dc13-11eb-852f-18f391981b28.png">


After:

<img width="695" alt="Screen Shot 2021-07-03 at 3 26 45 PM" src="https://user-images.githubusercontent.com/32864116/124346787-5bf1e180-dc13-11eb-80f8-8d2c5c443ba9.png">
