### PR TITLE
Fix font preloading warning

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -65,6 +65,7 @@
     <link rel="preload" as="font" href="%PUBLIC_URL%/fonts/Inter/web/woff2/Inter-Medium.woff2" type="font/woff2" crossorigin />
     <link rel="preload" as="font" href="%PUBLIC_URL%/fonts/Inter/web/woff2/Inter-SemiBold.woff2" type="font/woff2" crossorigin />
     <link rel="preload" as="font" href="%PUBLIC_URL%/fonts/Inter/web/woff2/Inter-Bold.woff2" type="font/woff2" crossorigin />
+    <link rel="stylesheet" type="text/css" href="%PUBLIC_URL%/fonts.css" media="screen">
 
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-56989641-1"></script>


### PR DESCRIPTION
Fixes the following warnings

<img width="1112" alt="Screen Shot 2021-07-04 at 9 53 19 AM" src="https://user-images.githubusercontent.com/32864116/124370800-ac1d8200-dcad-11eb-9e80-42cbfeb7568c.png">
