### PR TITLE
feat: add blog link in footer and top nav

### DIFF
--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -46,6 +46,11 @@ const navLists = [
         title: 'Community Guidelines',
         url: '/guidelines',
       },
+      {
+        isExternal: true,
+        title: 'Blog',
+        url: 'https://blog.thenewboston.com',
+      },
     ],
   },
   {

--- a/src/containers/TopNav/TopNavDesktopItems/index.tsx
+++ b/src/containers/TopNav/TopNavDesktopItems/index.tsx
@@ -36,6 +36,13 @@ const communityPopoverItems: TopNavPopoverItemType[] = [
     title: 'Community Guidelines',
     to: '/guidelines',
   },
+  {
+    description: 'Stay updated with our latest articles',
+    iconType: IconType.textBox,
+    isExternal: true,
+    title: 'Blog',
+    to: 'https://blog.thenewboston.com',
+  },
 ];
 
 const getStartedPopoverItems: TopNavPopoverItemType[] = [

--- a/src/containers/TopNav/TopNavMobileMenu/index.tsx
+++ b/src/containers/TopNav/TopNavMobileMenu/index.tsx
@@ -66,6 +66,7 @@ const TopNavMobileMenu: FC<ComponentProps> = ({closeMenu, menuOpen, smallDevice,
                 {renderMobileLink('Weekly Progress', '/progress')}
                 {renderMobileLink('Openings', '/openings')}
                 {renderMobileLink('Community Guidelines', '/guidelines')}
+                {renderMobileLink('Blog', 'https://blog.thenewboston.com', true)}
               </>,
             )}
             {renderColumn(


### PR DESCRIPTION
closes: #1928

The blog opens on the same tab right now. I think it would be better if we could open a new tab for it. I tried using `newWindow`, but it doesn't blend well with the rest of the nav links. It also adds extra space because of the icon(image below).
If a new tab is not required then this can be merged, else let me know.

![image](https://user-images.githubusercontent.com/29539278/124803556-e53c4780-df76-11eb-9451-cdd714754509.png)
