### PR TITLE
sfc for components

### DIFF
--- a/src/components/A/index.tsx
+++ b/src/components/A/index.tsx
@@ -1,13 +1,13 @@
-import React, {FC, ReactNode} from 'react';
+import React, {ReactNode} from 'react';
 import clsx from 'clsx';
 import {Icon, IconType} from '@thenewboston/ui';
 import {bemify} from '@thenewboston/utils';
+import {SFC} from 'types/generic';
 
 import './A.scss';
 
 interface ComponentProps {
   children?: ReactNode;
-  className?: string;
   dataTestId?: string;
   href: string;
   newWindow?: boolean;
@@ -15,7 +15,7 @@ interface ComponentProps {
   iconSize?: number;
 }
 
-const A: FC<ComponentProps> = ({
+const A: SFC<ComponentProps> = ({
   children,
   className,
   dataTestId = 'A',

--- a/src/components/AuthContainer/index.tsx
+++ b/src/components/AuthContainer/index.tsx
@@ -1,4 +1,6 @@
-import React, {FC, ReactNode} from 'react';
+import React, {ReactNode} from 'react';
+import clsx from 'clsx';
+import {SFC} from 'types/generic';
 
 import './AuthContainer.scss';
 
@@ -8,9 +10,9 @@ export interface AuthContainerProps {
   heading: string;
 }
 
-const AuthContainer: FC<AuthContainerProps> = ({children, errorMessage, heading}) => {
+const AuthContainer: SFC<AuthContainerProps> = ({children, className, errorMessage, heading}) => {
   return (
-    <div className="AuthContainer" data-testid="AuthContainer">
+    <div className={clsx('AuthContainer', className)} data-testid="AuthContainer">
       <h2>{heading}</h2>
       {errorMessage && (
         <div className="AuthContainer__error-message" data-testid="AuthContainer__error-message">

--- a/src/components/Avatar/index.tsx
+++ b/src/components/Avatar/index.tsx
@@ -1,20 +1,13 @@
 /* eslint-disable react/jsx-props-no-spreading */
 
-import React, {FC, Suspense, useEffect, useState} from 'react';
+import React, {Suspense, useEffect, useState} from 'react';
 import {useImage} from 'react-image';
 import clsx from 'clsx';
 
 import DefaultUserAvatar from 'assets/images/default-avatar.png';
+import {SFC} from 'types/generic';
 
 import './Avatar.scss';
-
-export interface AvatarProps {
-  bordered?: boolean;
-  className?: string;
-  size: number;
-  src: string;
-  onClick?(): void;
-}
 
 export const getImageSizeBasedOnDeviceRatio = (size: number): number => {
   const {devicePixelRatio} = window;
@@ -35,7 +28,14 @@ export const getFormattedSrc = (src: string, size: number): string => {
   }
 };
 
-const AvatarImgWithFallback: FC<AvatarProps> = ({bordered, className, onClick, size, src}) => {
+export interface AvatarProps {
+  bordered?: boolean;
+  size: number;
+  src: string;
+  onClick?(): void;
+}
+
+const AvatarImgWithFallback: SFC<AvatarProps> = ({bordered, className, onClick, size, src}) => {
   const [srcPrimary, setSrcPrimary] = useState<string>('');
   const {src: srcWithFallback} = useImage({srcList: [srcPrimary, DefaultUserAvatar]});
 
@@ -58,7 +58,7 @@ const AvatarImgWithFallback: FC<AvatarProps> = ({bordered, className, onClick, s
   );
 };
 
-const Avatar: FC<AvatarProps> = ({className, size, ...props}) => {
+const Avatar: SFC<AvatarProps> = ({className, size, ...props}) => {
   return (
     <Suspense
       fallback={

--- a/src/components/BreadcrumbMenu/index.tsx
+++ b/src/components/BreadcrumbMenu/index.tsx
@@ -1,20 +1,20 @@
-import React, {FC, ReactNode, useEffect, useState} from 'react';
+import React, {ReactNode, useEffect, useState} from 'react';
 import useOnclickOutside from 'react-cool-onclickoutside';
 import {useLocation} from 'react-router-dom';
 import clsx from 'clsx';
 import {Icon, IconType} from '@thenewboston/ui';
 
 import {Shadow} from 'components';
+import {SFC} from 'types/generic';
 import './BreadcrumbMenu.scss';
 
 interface ComponentProps {
-  className?: string;
   menuItems: ReactNode;
   pageName: string;
   sectionName: string;
 }
 
-const BreadcrumbMenu: FC<ComponentProps> = ({className, menuItems, pageName, sectionName}) => {
+const BreadcrumbMenu: SFC<ComponentProps> = ({className, menuItems, pageName, sectionName}) => {
   const {pathname} = useLocation();
   const [open, setOpen] = useState(false);
 

--- a/src/components/CodeSnippet/BaseCodeSnippet/index.tsx
+++ b/src/components/CodeSnippet/BaseCodeSnippet/index.tsx
@@ -1,4 +1,4 @@
-import React, {FC} from 'react';
+import React from 'react';
 import {PrismLight as SyntaxHighlighter} from 'react-syntax-highlighter';
 import {duotoneDark, solarizedlight} from 'react-syntax-highlighter/dist/esm/styles/prism';
 import bashLang from 'react-syntax-highlighter/dist/esm/languages/prism/bash';
@@ -7,6 +7,8 @@ import jsxLang from 'react-syntax-highlighter/dist/esm/languages/prism/jsx';
 import pythonLang from 'react-syntax-highlighter/dist/esm/languages/prism/python';
 import scssLang from 'react-syntax-highlighter/dist/esm/languages/prism/scss';
 import typescriptLang from 'react-syntax-highlighter/dist/esm/languages/prism/typescript';
+
+import {SFC} from 'types/generic';
 
 export enum SnippetLang {
   bash = 'bash',
@@ -31,7 +33,7 @@ export interface BaseCodeSnippetProps {
   showLineNumbers?: boolean;
 }
 
-const BaseCodeSnippet: FC<BaseCodeSnippetProps> = ({code, language, light = false, showLineNumbers = true}) => {
+const BaseCodeSnippet: SFC<BaseCodeSnippetProps> = ({code, language, light = false, showLineNumbers = true}) => {
   return (
     <SyntaxHighlighter
       language={language}

--- a/src/components/CodeSnippet/CodeSnippet/index.tsx
+++ b/src/components/CodeSnippet/CodeSnippet/index.tsx
@@ -1,18 +1,18 @@
-import React, {FC} from 'react';
+import React from 'react';
 import clsx from 'clsx';
 import {bemify} from '@thenewboston/utils';
+import {SFC} from 'types/generic';
 
 import BaseCodeSnippet, {SnippetLang} from '../BaseCodeSnippet';
 import './CodeSnippet.scss';
 
 interface ComponentProps {
-  className?: string;
   code: string;
   heading?: string;
   language?: SnippetLang;
 }
 
-const CodeSnippet: FC<ComponentProps> = ({className, code, heading, language = SnippetLang.bash}) => {
+const CodeSnippet: SFC<ComponentProps> = ({className, code, heading, language = SnippetLang.bash}) => {
   return (
     <div className={clsx('CodeSnippet', className)} data-testid="CodeSnippet">
       {heading ? (

--- a/src/components/CodeSnippet/RequestResponseSnippet/index.tsx
+++ b/src/components/CodeSnippet/RequestResponseSnippet/index.tsx
@@ -1,17 +1,17 @@
-import React, {FC} from 'react';
+import React from 'react';
 import clsx from 'clsx';
 import {bemify} from '@thenewboston/utils';
+import {SFC} from 'types/generic';
 
 import BaseCodeSnippet, {SnippetLang} from '../BaseCodeSnippet';
 import './RequestResponseSnippet.scss';
 
 export interface RequestResponseSnippetProps {
-  className?: string;
   code: string;
   heading?: string;
 }
 
-const RequestResponse: FC<RequestResponseSnippetProps> = ({className, code, heading}) => {
+const RequestResponse: SFC<RequestResponseSnippetProps> = ({className, code, heading}) => {
   return (
     <div className={clsx('RequestResponseSnippet', className)} data-testid="RequestResponseSnippet">
       {heading ? (

--- a/src/components/Container/index.tsx
+++ b/src/components/Container/index.tsx
@@ -1,20 +1,20 @@
 /* eslint-disable react/jsx-props-no-spreading */
 
-import React, {FC, useMemo} from 'react';
+import React, {useMemo} from 'react';
 import clsx from 'clsx';
+import {SFC} from 'types/generic';
 
 import './Container.scss';
 
 type ContainerElement = 'div' | 'header' | 'main';
 
 interface ContainerProps {
-  className?: string;
   element?: ContainerElement;
   dataTestId?: string;
   maxWidth?: number;
 }
 
-const Container: FC<ContainerProps> = ({children, className, dataTestId, element = 'div', maxWidth = 1366}) => {
+const Container: SFC<ContainerProps> = ({children, className, dataTestId, element = 'div', maxWidth = 1366}) => {
   const props = useMemo(
     () => ({
       className: clsx('Container', className),

--- a/src/components/ContributorTasks/ContributorTasks.test.tsx
+++ b/src/components/ContributorTasks/ContributorTasks.test.tsx
@@ -2,9 +2,10 @@ import React from 'react';
 import {render, screen} from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
+import {ClassName} from 'types/generic';
 import ContributorTasks, {ContributorTasksProps} from '.';
 
-const props: ContributorTasksProps = {
+const props: ContributorTasksProps & ClassName = {
   className: 'test',
   tasks: [
     {

--- a/src/components/ContributorTasks/index.tsx
+++ b/src/components/ContributorTasks/index.tsx
@@ -1,17 +1,17 @@
-import React, {FC} from 'react';
+import React from 'react';
 import clsx from 'clsx';
 import format from 'date-fns/format';
 
 import {A} from 'components';
+import {SFC} from 'types/generic';
 import {Task} from 'types/github';
 import './ContributorTasks.scss';
 
 export interface ContributorTasksProps {
-  className?: string;
   tasks: Task[];
 }
 
-const ContributorTasks: FC<ContributorTasksProps> = ({className, tasks}) => {
+const ContributorTasks: SFC<ContributorTasksProps> = ({className, tasks}) => {
   const renderRows = () => {
     return tasks.map(({amount_paid, completed_date, issue_id, repository, title}: Task, index) => (
       <tr key={index} data-testid="ContributorTasks__row">

--- a/src/components/CopyableAccountNumber/index.tsx
+++ b/src/components/CopyableAccountNumber/index.tsx
@@ -1,19 +1,19 @@
-import React, {FC} from 'react';
+import React from 'react';
 import CopyToClipboard from 'react-copy-to-clipboard';
 import clsx from 'clsx';
 import {Icon, IconType} from '@thenewboston/ui';
 
+import {SFC} from 'types/generic';
 import {displayToast} from 'utils/toast';
 
 import './CopyableAccountNumber.scss';
 
 interface ComponentProps {
   accountNumber: string;
-  className?: string;
   isCopyButtonAtBottom?: boolean;
 }
 
-const CopyableAccountNumber: FC<ComponentProps> = ({accountNumber, className, isCopyButtonAtBottom}) => {
+const CopyableAccountNumber: SFC<ComponentProps> = ({accountNumber, className, isCopyButtonAtBottom}) => {
   const handleCopy = (): void => {
     displayToast('Account Number copied to the clipboard', 'success');
   };

--- a/src/components/DashboardLayout/index.tsx
+++ b/src/components/DashboardLayout/index.tsx
@@ -1,6 +1,8 @@
-import React, {FC, ReactNode} from 'react';
+import React, {ReactNode} from 'react';
+import clsx from 'clsx';
 
 import {BreadcrumbMenu, Container, PageTitle} from 'components';
+import {SFC} from 'types/generic';
 import './DashboardLayout.scss';
 
 export interface DashboardLayoutProps {
@@ -10,11 +12,11 @@ export interface DashboardLayoutProps {
   sectionName: string;
 }
 
-const DashboardLayout: FC<DashboardLayoutProps> = ({children, menuItems, pageName, sectionName}) => {
+const DashboardLayout: SFC<DashboardLayoutProps> = ({children, className, menuItems, pageName, sectionName}) => {
   return (
     <>
       <PageTitle title={`${sectionName}`} />
-      <Container className="DashboardLayout">
+      <Container className={clsx('DashboardLayout', className)}>
         <BreadcrumbMenu
           className="DashboardLayout__BreadcrumbMenu"
           menuItems={menuItems}

--- a/src/components/DataTable/index.tsx
+++ b/src/components/DataTable/index.tsx
@@ -1,15 +1,15 @@
+import React, {ReactNode} from 'react';
 import clsx from 'clsx';
-import React, {FC, ReactNode} from 'react';
+import {SFC} from 'types/generic';
 
 import './DataTable.scss';
 
 type Props = {
-  className?: string;
   columns: ReactNode[];
   data: ReactNode[][];
 };
 
-const DataTable: FC<Props> = ({className, columns, data}) => {
+const DataTable: SFC<Props> = ({className, columns, data}) => {
   const renderTableHeaders = (cols: ReactNode[]): ReactNode => {
     return (
       <>

--- a/src/components/Divider/index.tsx
+++ b/src/components/Divider/index.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-
 import clsx from 'clsx';
+import {SFC} from 'types/generic';
 import './Divider.scss';
 
-const Divider = ({className}: {className?: string}) => {
+const Divider: SFC = ({className}) => {
   return <div className={clsx('Divider', className)} />;
 };
 

--- a/src/components/DocWrapper/DocCallout/DocCallout.test.tsx
+++ b/src/components/DocWrapper/DocCallout/DocCallout.test.tsx
@@ -2,9 +2,10 @@ import React from 'react';
 import {render, screen} from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
+import {ClassName} from 'types/generic';
 import DocCallout, {CalloutType, DocCalloutProps} from '.';
 
-const baseProps: DocCalloutProps = {
+const baseProps: DocCalloutProps & ClassName = {
   className: 'Test',
   type: CalloutType.note,
 };

--- a/src/components/DocWrapper/DocCallout/index.tsx
+++ b/src/components/DocWrapper/DocCallout/index.tsx
@@ -1,9 +1,10 @@
-import React, {FC, useMemo} from 'react';
+import React, {useMemo} from 'react';
 import clsx from 'clsx';
 import capitalize from 'lodash/capitalize';
 import {Icon, IconType} from '@thenewboston/ui';
 import {bemify} from '@thenewboston/utils';
 
+import {SFC} from 'types/generic';
 import './DocCallout.scss';
 
 export enum CalloutType {
@@ -13,11 +14,10 @@ export enum CalloutType {
 }
 
 export interface DocCalloutProps {
-  className?: string;
   type: CalloutType;
 }
 
-const DocCallout: FC<DocCalloutProps> = ({children, className, type}) => {
+const DocCallout: SFC<DocCalloutProps> = ({children, className, type}) => {
   const modifier = useMemo<string>(() => `--${type}`, [type]);
 
   const icon = useMemo(() => {

--- a/src/components/DocWrapper/DocContainer/DocContainer.test.tsx
+++ b/src/components/DocWrapper/DocContainer/DocContainer.test.tsx
@@ -2,9 +2,10 @@ import React from 'react';
 import {render, screen} from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
+import {ClassName} from 'types/generic';
 import DocContainer, {DocContainerProps} from '.';
 
-const baseProps: DocContainerProps = {
+const baseProps: DocContainerProps & ClassName = {
   className: 'Test',
   id: 'test-id',
   lastUpdated: '06 Mar 2021',

--- a/src/components/DocWrapper/DocContainer/index.tsx
+++ b/src/components/DocWrapper/DocContainer/index.tsx
@@ -1,19 +1,19 @@
-import React, {FC, ReactNode} from 'react';
+import React, {ReactNode} from 'react';
 import clsx from 'clsx';
 import {bemify} from '@thenewboston/utils';
 
 import {HashLink} from 'components';
+import {SFC} from 'types/generic';
 
 import './DocContainer.scss';
 
 export interface DocContainerProps {
-  className?: string;
   id?: string;
   lastUpdated?: string;
   title: ReactNode;
 }
 
-const DocContainer: FC<DocContainerProps> = ({children, className, id, lastUpdated, title}) => {
+const DocContainer: SFC<DocContainerProps> = ({children, className, id, lastUpdated, title}) => {
   return (
     <section className={clsx('DocContainer', className)} data-testid="DocContainer">
       <div

--- a/src/components/DocWrapper/DocEndpoint/index.tsx
+++ b/src/components/DocWrapper/DocEndpoint/index.tsx
@@ -1,15 +1,15 @@
-import React, {FC} from 'react';
+import React from 'react';
 import clsx from 'clsx';
+import {SFC} from 'types/generic';
 
 import './DocEndpoint.scss';
 
 export interface DocEndpointProps {
-  className?: string;
   endpoint: string;
   method: 'GET' | 'POST' | 'PATCH' | 'DELETE';
 }
 
-const DocEndpoint: FC<DocEndpointProps> = ({className, endpoint, method}) => {
+const DocEndpoint: SFC<DocEndpointProps> = ({className, endpoint, method}) => {
   return (
     <h2 className={clsx('DocEndpoint', className)} data-testid="DocEndpoint">
       {method} {endpoint}

--- a/src/components/DocWrapper/DocImage/index.tsx
+++ b/src/components/DocWrapper/DocImage/index.tsx
@@ -1,6 +1,7 @@
-import React, {FC} from 'react';
+import React from 'react';
 import clsx from 'clsx';
 import {bemify} from '@thenewboston/utils';
+import {SFC} from 'types/generic';
 
 import './DocImage.scss';
 
@@ -13,7 +14,7 @@ export interface DocImageProps {
   src: string;
 }
 
-const DocImage: FC<DocImageProps> = ({alt, bordered, className, maxWidth, src, width}) => {
+const DocImage: SFC<DocImageProps> = ({alt, bordered, className, maxWidth, src, width}) => {
   return (
     <div className={clsx('DocImage', className)} data-testid="DocImage">
       <img

--- a/src/components/DocWrapper/DocInlineCode/index.tsx
+++ b/src/components/DocWrapper/DocInlineCode/index.tsx
@@ -1,13 +1,10 @@
-import React, {FC} from 'react';
+import React from 'react';
 import clsx from 'clsx';
+import {SFC} from 'types/generic';
 
 import './DocInlineCode.scss';
 
-interface ComponentProps {
-  className?: string;
-}
-
-const DocInlineCode: FC<ComponentProps> = ({children, className}) => {
+const DocInlineCode: SFC = ({children, className}) => {
   return (
     <code className={clsx('DocInlineCode', className)} data-testid="DocInlineCode">
       {children}

--- a/src/components/DocWrapper/DocList/DocList.test.tsx
+++ b/src/components/DocWrapper/DocList/DocList.test.tsx
@@ -2,9 +2,10 @@ import React from 'react';
 import {render, screen} from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
+import {ClassName} from 'types/generic';
 import DocList, {DocListProps} from './index';
 
-const props: DocListProps = {
+const props: DocListProps & ClassName = {
   className: 'test-class',
   variant: 'ul',
 };

--- a/src/components/DocWrapper/DocList/index.tsx
+++ b/src/components/DocWrapper/DocList/index.tsx
@@ -1,15 +1,15 @@
-import React, {FC, useMemo} from 'react';
+import React, {useMemo} from 'react';
 import clsx from 'clsx';
 import {bemify} from '@thenewboston/utils';
 
+import {SFC} from 'types/generic';
 import './DocList.scss';
 
 export interface DocListProps {
-  className?: string;
   variant: 'ul' | 'ol';
 }
 
-const DocList: FC<DocListProps> = ({children, className, variant}) => {
+const DocList: SFC<DocListProps> = ({children, className, variant}) => {
   const mainClassName = useMemo(
     () =>
       clsx('DocList', className, {

--- a/src/components/DocWrapper/DocSubHeader/index.tsx
+++ b/src/components/DocWrapper/DocSubHeader/index.tsx
@@ -1,13 +1,10 @@
-import React, {FC} from 'react';
+import React from 'react';
 import clsx from 'clsx';
+import {SFC} from 'types/generic';
 
 import './DocSubHeader.scss';
 
-interface ComponentProps {
-  className?: string;
-}
-
-const DocSubHeader: FC<ComponentProps> = ({children, className}) => {
+const DocSubHeader: SFC = ({children, className}) => {
   return (
     <h3 className={clsx('DocSubHeader', className)} data-testid="DocSubHeader">
       {children}

--- a/src/components/DocWrapper/DocSubSection/DocSubSection.test.tsx
+++ b/src/components/DocWrapper/DocSubSection/DocSubSection.test.tsx
@@ -2,9 +2,10 @@ import React from 'react';
 import {render, screen} from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
+import {ClassName} from 'types/generic';
 import DocSubSection, {DocSubSectionProps} from './index';
 
-const props: DocSubSectionProps = {
+const props: DocSubSectionProps & ClassName = {
   className: 'className-test',
   id: 'id-test',
   title: 'title-test',

--- a/src/components/DocWrapper/DocSubSection/index.tsx
+++ b/src/components/DocWrapper/DocSubSection/index.tsx
@@ -1,18 +1,18 @@
-import React, {FC, ReactNode} from 'react';
+import React, {ReactNode} from 'react';
 import clsx from 'clsx';
 import {bemify} from '@thenewboston/utils';
 
 import {HashLink} from 'components';
+import {SFC} from 'types/generic';
 
 import './DocSubSection.scss';
 
 export interface DocSubSectionProps {
-  className?: string;
   id?: string;
   title: ReactNode;
 }
 
-const DocSubSection: FC<DocSubSectionProps> = ({children, className, id, title}) => {
+const DocSubSection: SFC<DocSubSectionProps> = ({children, className, id, title}) => {
   return (
     <>
       <h2 className={clsx('DocSubSection__h2', {...bemify(className, '__h2')})} data-testid="DocSubSection__h2" id={id}>

--- a/src/components/DocsMenuItems/index.tsx
+++ b/src/components/DocsMenuItems/index.tsx
@@ -1,7 +1,8 @@
-import React, {FC} from 'react';
+import React from 'react';
 import {NavLink} from 'react-router-dom';
 
 import {MenuGroup} from 'components';
+import {SFC} from 'types/generic';
 import {NavigationItem} from 'types/navigation';
 
 export const walletNavigationData = [
@@ -39,7 +40,7 @@ export const walletNavigationData = [
   },
 ];
 
-const DocsMenuItems: FC = () => {
+const DocsMenuItems: SFC = () => {
   const renderNavLinks = (navigationData: NavigationItem[]) => {
     return navigationData.map(({name, url}) => (
       <NavLink key={url} to={url}>

--- a/src/components/DropdownInput/index.tsx
+++ b/src/components/DropdownInput/index.tsx
@@ -1,5 +1,7 @@
-import React, {FC, useState} from 'react';
+import React, {useState} from 'react';
+import clsx from 'clsx';
 import {Icon, IconType} from '@thenewboston/ui';
+import {SFC} from 'types/generic';
 
 import './DropdownInput.scss';
 
@@ -9,7 +11,7 @@ interface ComponentProps<T> {
   options: T[];
 }
 
-const DropdownInput: FC<ComponentProps<string>> = ({callbackOnChange, defaultOption, options}) => {
+const DropdownInput: SFC<ComponentProps<string>> = ({callbackOnChange, className, defaultOption, options}) => {
   const [selectedOption, setSelectedOption] = useState<string>(defaultOption);
   const handleChange = (e: React.FormEvent) => {
     const {value} = e.target as HTMLSelectElement;
@@ -17,7 +19,7 @@ const DropdownInput: FC<ComponentProps<string>> = ({callbackOnChange, defaultOpt
     callbackOnChange(value);
   };
   return (
-    <div className="DropdownInput" data-testid="DropdownInput">
+    <div className={clsx('DropdownInput', className)} data-testid="DropdownInput">
       <select
         className="DropdownInput__select-box"
         data-testid="DropdownInput__select-box"

--- a/src/components/EmptyPage/index.tsx
+++ b/src/components/EmptyPage/index.tsx
@@ -1,13 +1,10 @@
-import React, {FC} from 'react';
+import React from 'react';
 import clsx from 'clsx';
+import {SFC} from 'types/generic';
 
 import './EmptyPage.scss';
 
-interface ComponentProps {
-  className?: string;
-}
-
-const EmptyPage: FC<ComponentProps> = ({className}) => {
+const EmptyPage: SFC = ({className}) => {
   return (
     <div className={clsx('EmptyPage', className)} data-testid="EmptyPage">
       <h1>No items to display</h1>

--- a/src/components/FaqDropdownCard/index.tsx
+++ b/src/components/FaqDropdownCard/index.tsx
@@ -1,20 +1,20 @@
-import React, {FC, ReactNode, useEffect} from 'react';
+import React, {ReactNode, useEffect} from 'react';
 import {Link, useLocation} from 'react-router-dom';
 import clsx from 'clsx';
 import {Icon, IconType} from '@thenewboston/ui';
 
 import {useBooleanState} from 'hooks';
 import {HashLink} from 'components';
+import {SFC} from 'types/generic';
 import './FaqDropdownCard.scss';
 
 type Props = {
   answer: ReactNode;
-  className?: string;
   id: string;
   question: ReactNode;
 };
 
-const FaqDropdownCard: FC<Props> = ({answer, className, id, question}) => {
+const FaqDropdownCard: SFC<Props> = ({answer, className, id, question}) => {
   const {hash, pathname} = useLocation();
   const [expanded, toggleExpanded, setExpandedAsTrue] = useBooleanState(false);
 

--- a/src/components/FlatNavLinks/index.tsx
+++ b/src/components/FlatNavLinks/index.tsx
@@ -2,18 +2,18 @@ import React from 'react';
 import clsx from 'clsx';
 import {bemify} from '@thenewboston/utils';
 
+import {SFC} from 'types/generic';
 import {NavOption} from 'types/option';
 
 import './FlatNavLinks.scss';
 
 export interface FlatNavLinksProps {
-  className?: string;
   handleOptionClick(option: string): () => void;
   options: NavOption[];
   selectedOption: string;
 }
 
-function FlatNavLinks({className, handleOptionClick, options, selectedOption}: FlatNavLinksProps) {
+const FlatNavLinks: SFC<FlatNavLinksProps> = ({className, handleOptionClick, options, selectedOption}) => {
   const renderOptions = () => {
     return options.map((option: NavOption) => (
       <button
@@ -35,6 +35,6 @@ function FlatNavLinks({className, handleOptionClick, options, selectedOption}: F
       {renderOptions()}
     </div>
   );
-}
+};
 
 export default FlatNavLinks;

--- a/src/components/FormComponents/Form/index.tsx
+++ b/src/components/FormComponents/Form/index.tsx
@@ -1,9 +1,9 @@
-import React, {FC} from 'react';
+import React from 'react';
 import {Form as FormikForm, Formik} from 'formik';
 import {GenericFormValues} from 'types/forms';
+import {SFC} from 'types/generic';
 
 interface ComponentProps {
-  className?: string;
   children: ({isValid}: {isValid: boolean}) => JSX.Element;
   initialValues?: GenericFormValues;
   onSubmit(values: GenericFormValues): void | Promise<any>;
@@ -11,7 +11,7 @@ interface ComponentProps {
   validationSchema?: any;
 }
 
-const Form: FC<ComponentProps> = ({
+const Form: SFC<ComponentProps> = ({
   children,
   className,
   onSubmit,

--- a/src/components/FormComponents/FormButton/index.tsx
+++ b/src/components/FormComponents/FormButton/index.tsx
@@ -1,15 +1,16 @@
 /* eslint-disable react/jsx-props-no-spreading */
 
-import React, {FC, useMemo} from 'react';
+import React, {useMemo} from 'react';
 import {useFormikContext} from 'formik';
 import {BaseButtonProps, Button, Loader} from 'components/FormElements';
+import {SFC} from 'types/generic';
 
 export interface FormButtonProps extends BaseButtonProps {
   ignoreDirty?: boolean;
   submitting?: boolean;
 }
 
-const FormButton: FC<FormButtonProps> = ({children, ignoreDirty = false, submitting = false, ...baseButtonProps}) => {
+const FormButton: SFC<FormButtonProps> = ({children, ignoreDirty = false, submitting = false, ...baseButtonProps}) => {
   const {disabled = false, onClick, type = 'button'} = baseButtonProps;
   const {dirty, handleReset, handleSubmit, isValid} = useFormikContext();
 

--- a/src/components/FormComponents/FormInput/index.tsx
+++ b/src/components/FormComponents/FormInput/index.tsx
@@ -1,17 +1,18 @@
 /* eslint-disable react/jsx-props-no-spreading */
 
-import React, {ChangeEvent, FC} from 'react';
+import React, {ChangeEvent} from 'react';
 import {Field} from 'formik';
 import clsx from 'clsx';
 
 import {BaseInputProps, Input} from 'components/FormElements';
 import {useFormContext} from 'hooks';
 import {BaseFormComponentProps} from 'types/forms';
+import {SFC} from 'types/generic';
 import {renderFormError, renderFormLabel} from 'utils/forms';
 
 type ComponentProps = BaseFormComponentProps<BaseInputProps>;
 
-const FormInput: FC<ComponentProps> = ({
+const FormInput: SFC<ComponentProps> = ({
   hideErrorBlock = false,
   hideErrorText = false,
   label,

--- a/src/components/FormComponents/FormRadioGroup/index.tsx
+++ b/src/components/FormComponents/FormRadioGroup/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/jsx-props-no-spreading */
 
-import React, {FC, useMemo, useState} from 'react';
+import React, {useMemo, useState} from 'react';
 import clsx from 'clsx';
 import noop from 'lodash/noop';
 import {bemify} from '@thenewboston/utils';
@@ -8,6 +8,7 @@ import {bemify} from '@thenewboston/utils';
 import {BaseRadioProps, Radio} from 'components/FormElements';
 import {useFormContext} from 'hooks';
 import {BaseFormComponentProps, InputOption} from 'types/forms';
+import {SFC} from 'types/generic';
 import {renderFormError, renderFormLabel} from 'utils/forms';
 
 interface BaseRadioGroupProps extends Omit<BaseRadioProps, 'checked'> {
@@ -16,7 +17,7 @@ interface BaseRadioGroupProps extends Omit<BaseRadioProps, 'checked'> {
 
 type ComponentProps = BaseFormComponentProps<BaseRadioGroupProps>;
 
-const FormRadioGroup: FC<ComponentProps> = ({
+const FormRadioGroup: SFC<ComponentProps> = ({
   focused = false,
   hideErrorText = false,
   label,

--- a/src/components/FormComponents/FormSelect/index.tsx
+++ b/src/components/FormComponents/FormSelect/index.tsx
@@ -1,16 +1,17 @@
 /* eslint-disable react/jsx-props-no-spreading */
 
-import React, {FC} from 'react';
+import React from 'react';
 import clsx from 'clsx';
 
 import {BaseSelectProps, Select} from 'components/FormElements';
 import useFormSelect from 'hooks/useFormSelect';
 import {BaseFormComponentProps} from 'types/forms';
+import {SFC} from 'types/generic';
 import {renderFormError, renderFormLabel} from 'utils/forms';
 
 type ComponentProps = BaseFormComponentProps<BaseSelectProps>;
 
-const FormSelect: FC<ComponentProps> = ({hideErrorText = false, label, required, ...baseSelectProps}) => {
+const FormSelect: SFC<ComponentProps> = ({hideErrorText = false, label, required, ...baseSelectProps}) => {
   const {className, name, options} = baseSelectProps;
   const {error, handleBlur, handleChange, selectedOption} = useFormSelect(name, options, baseSelectProps);
 

--- a/src/components/FormComponents/FormSelectDetailed/index.tsx
+++ b/src/components/FormComponents/FormSelectDetailed/index.tsx
@@ -1,16 +1,17 @@
 /* eslint-disable react/jsx-props-no-spreading */
 
-import React, {FC} from 'react';
+import React from 'react';
 import clsx from 'clsx';
 
 import {BaseSelectProps, SelectDetailed} from 'components/FormElements';
 import useFormSelect from 'hooks/useFormSelect';
 import {BaseFormComponentProps} from 'types/forms';
+import {SFC} from 'types/generic';
 import {renderFormError, renderFormLabel} from 'utils/forms';
 
 type ComponentProps = BaseFormComponentProps<BaseSelectProps>;
 
-const FormSelectDetailed: FC<ComponentProps> = ({hideErrorText = false, label, required, ...baseSelectProps}) => {
+const FormSelectDetailed: SFC<ComponentProps> = ({hideErrorText = false, label, required, ...baseSelectProps}) => {
   const {className, name, options} = baseSelectProps;
   const {error, handleBlur, handleChange, selectedOption} = useFormSelect(name, options, baseSelectProps);
 

--- a/src/components/FormComponents/FormTextArea/index.tsx
+++ b/src/components/FormComponents/FormTextArea/index.tsx
@@ -1,17 +1,18 @@
 /* eslint-disable react/jsx-props-no-spreading */
 
-import React, {FC} from 'react';
+import React from 'react';
 import {Field} from 'formik';
 import clsx from 'clsx';
 
 import {BaseInputProps, TextArea} from 'components/FormElements';
 import {useFormContext} from 'hooks';
 import {BaseFormComponentProps} from 'types/forms';
+import {SFC} from 'types/generic';
 import {renderFormError, renderFormLabel} from 'utils/forms';
 
 type ComponentProps = BaseFormComponentProps<BaseInputProps>;
 
-const FormTextArea: FC<ComponentProps> = ({hideErrorText = false, label, required = false, ...baseInputProps}) => {
+const FormTextArea: SFC<ComponentProps> = ({hideErrorText = false, label, required = false, ...baseInputProps}) => {
   const {className, name} = baseInputProps;
   const {errors, touched} = useFormContext();
   const error = !!errors[name] && !!touched[name];

--- a/src/components/FormElements/Button/index.tsx
+++ b/src/components/FormElements/Button/index.tsx
@@ -1,11 +1,11 @@
-import React, {FC, useEffect, useRef} from 'react';
+import React, {useEffect, useRef} from 'react';
 import clsx from 'clsx';
 import {bemify} from '@thenewboston/utils';
+import {SFC} from 'types/generic';
 
 import './Button.scss';
 
 export interface BaseButtonProps {
-  className?: string;
   color?: 'primary' | 'secondary' | 'tertiary';
   disabled?: boolean;
   focused?: boolean;
@@ -14,7 +14,7 @@ export interface BaseButtonProps {
   variant?: 'contained' | 'link' | 'outlined';
 }
 
-const Button: FC<BaseButtonProps> = ({
+const Button: SFC<BaseButtonProps> = ({
   children,
   color = 'primary',
   className,

--- a/src/components/FormElements/ErrorMessage/index.tsx
+++ b/src/components/FormElements/ErrorMessage/index.tsx
@@ -1,15 +1,12 @@
-import React, {FC} from 'react';
+import React from 'react';
 import clsx from 'clsx';
 import {Icon, IconType} from '@thenewboston/ui';
 import {bemify} from '@thenewboston/utils';
+import {SFC} from 'types/generic';
 
 import './ErrorMessage.scss';
 
-interface ErrorMessageProps {
-  className?: string;
-}
-
-const ErrorMessage: FC<ErrorMessageProps> = ({children, className}) => {
+const ErrorMessage: SFC = ({children, className}) => {
   return (
     <div className={clsx('ErrorMessage', className)}>
       <Icon

--- a/src/components/FormElements/Input/index.tsx
+++ b/src/components/FormElements/Input/index.tsx
@@ -1,12 +1,12 @@
-import React, {ChangeEvent, FC, FocusEvent, useEffect, useRef} from 'react';
+import React, {ChangeEvent, FocusEvent, useEffect, useRef} from 'react';
 import clsx from 'clsx';
 import {bemify} from '@thenewboston/utils';
+import {SFC} from 'types/generic';
 
 import './Input.scss';
 
 export interface BaseInputProps {
   autoComplete?: 'email' | 'current-password' | 'new-password';
-  className?: string;
   disabled?: boolean;
   error?: boolean;
   focused?: boolean;
@@ -20,7 +20,7 @@ export interface BaseInputProps {
   value: string;
 }
 
-const Input: FC<BaseInputProps> = ({
+const Input: SFC<BaseInputProps> = ({
   autoComplete,
   className,
   disabled = false,

--- a/src/components/FormElements/Loader/index.tsx
+++ b/src/components/FormElements/Loader/index.tsx
@@ -1,14 +1,11 @@
-import React, {FC, memo} from 'react';
+import React, {memo} from 'react';
 import clsx from 'clsx';
 import {Icon, IconType} from '@thenewboston/ui';
+import {SFC} from 'types/generic';
 
 import './Loader.scss';
 
-interface ComponentProps {
-  className?: string;
-}
-
-const Loader: FC<ComponentProps> = ({className}) => {
+const Loader: SFC = ({className}) => {
   return <Icon className={clsx('Loader', className)} icon={IconType.loading} size={15.35} totalSize="unset" />;
 };
 

--- a/src/components/FormElements/Radio/index.tsx
+++ b/src/components/FormElements/Radio/index.tsx
@@ -1,13 +1,13 @@
-import React, {FC, useEffect, useRef} from 'react';
+import React, {useEffect, useRef} from 'react';
 import clsx from 'clsx';
 import {Icon, IconType} from '@thenewboston/ui';
 import {bemify} from '@thenewboston/utils';
+import {SFC} from 'types/generic';
 
 import './Radio.scss';
 
 export interface BaseRadioProps {
   checked: boolean;
-  className?: string;
   disabled?: boolean;
   error?: boolean;
   focused?: boolean;
@@ -19,7 +19,7 @@ export interface BaseRadioProps {
   value: string;
 }
 
-const Radio: FC<BaseRadioProps> = ({
+const Radio: SFC<BaseRadioProps> = ({
   checked,
   className,
   disabled = false,

--- a/src/components/FormElements/Select/index.tsx
+++ b/src/components/FormElements/Select/index.tsx
@@ -1,18 +1,18 @@
 /* eslint-disable react/jsx-props-no-spreading */
 
-import React, {FC, ReactNode, useMemo} from 'react';
+import React, {ReactNode, useMemo} from 'react';
 import ReactSelect, {ActionMeta, FocusEventHandler, FormatOptionLabelMeta} from 'react-select';
 import ReactSelectCreatable from 'react-select/creatable';
 import {ValueType} from 'react-select/src/types';
 import clsx from 'clsx';
 import {bemify} from '@thenewboston/utils';
 
+import {SFC} from 'types/generic';
 import {InputOption} from 'types/forms';
 
 import './Select.scss';
 
 export interface BaseSelectProps {
-  className?: string;
   clearable?: boolean;
   creatable?: boolean;
   disabled?: boolean;
@@ -32,7 +32,7 @@ interface ComponentProps extends BaseSelectProps {
   formatOptionLabel?(option: InputOption, labelMeta: FormatOptionLabelMeta<InputOption>): ReactNode;
 }
 
-const Select: FC<ComponentProps> = ({
+const Select: SFC<ComponentProps> = ({
   className,
   clearable = false,
   creatable = false,

--- a/src/components/FormElements/SelectDetailed/index.tsx
+++ b/src/components/FormElements/SelectDetailed/index.tsx
@@ -1,11 +1,12 @@
 /* eslint-disable react/jsx-props-no-spreading */
 
-import React, {FC, ReactNode} from 'react';
+import React, {ReactNode} from 'react';
 import {FormatOptionLabelMeta} from 'react-select';
 import clsx from 'clsx';
 
 import {BaseSelectProps, Select} from 'components/FormElements';
 import {InputOption} from 'types/forms';
+import {SFC} from 'types/generic';
 
 import './SelectDetailed.scss';
 
@@ -30,7 +31,7 @@ const formatOptionLabel = ({value, label}: InputOption, {context}: FormatOptionL
   );
 };
 
-const SelectDetailed: FC<BaseSelectProps> = ({...baseSelectProps}) => {
+const SelectDetailed: SFC<BaseSelectProps> = ({...baseSelectProps}) => {
   const {className} = baseSelectProps;
 
   return (

--- a/src/components/FormElements/TextArea/index.tsx
+++ b/src/components/FormElements/TextArea/index.tsx
@@ -1,11 +1,11 @@
-import React, {ChangeEvent, FC, FocusEvent, useEffect, useRef} from 'react';
+import React, {ChangeEvent, FocusEvent, useEffect, useRef} from 'react';
 import clsx from 'clsx';
 import {bemify} from '@thenewboston/utils';
+import {SFC} from 'types/generic';
 
 import './TextArea.scss';
 
 export interface BaseInputProps {
-  className?: string;
   disabled?: boolean;
   error?: boolean;
   focused?: boolean;
@@ -16,7 +16,7 @@ export interface BaseInputProps {
   value: string;
 }
 
-const InputTextArea: FC<BaseInputProps> = ({
+const InputTextArea: SFC<BaseInputProps> = ({
   className,
   disabled = false,
   error = false,

--- a/src/components/GoToTop/index.tsx
+++ b/src/components/GoToTop/index.tsx
@@ -1,9 +1,11 @@
-import React, {FC, useCallback, useEffect, useState} from 'react';
+import React, {useCallback, useEffect, useState} from 'react';
+import clsx from 'clsx';
 import {Icon, IconType} from '@thenewboston/ui';
+import {SFC} from 'types/generic';
 
 import './GoToTop.scss';
 
-const GoToTop: FC = () => {
+const GoToTop: SFC = ({className}) => {
   const [show, setShow] = useState<boolean>(false);
 
   const handleScroll = useCallback(() => {
@@ -26,7 +28,13 @@ const GoToTop: FC = () => {
   return (
     <>
       {show && (
-        <Icon className="GoToTop" dataTestId="GoToTop" icon={IconType.chevronUp} size={50} onClick={scrollTop} />
+        <Icon
+          className={clsx('GoToTop', className)}
+          dataTestId="GoToTop"
+          icon={IconType.chevronUp}
+          size={50}
+          onClick={scrollTop}
+        />
       )}
     </>
   );

--- a/src/components/HashLink/HashLink.test.tsx
+++ b/src/components/HashLink/HashLink.test.tsx
@@ -2,9 +2,10 @@ import React from 'react';
 import {render, screen} from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
+import {ClassName} from 'types/generic';
 import HashLink, {HashLinkProps} from './index';
 
-const props: HashLinkProps = {
+const props: HashLinkProps & ClassName = {
   className: 'className-test',
   id: 'id-test',
 };

--- a/src/components/HashLink/index.tsx
+++ b/src/components/HashLink/index.tsx
@@ -1,14 +1,14 @@
-import React, {FC} from 'react';
+import React from 'react';
 import clsx from 'clsx';
+import {SFC} from 'types/generic';
 
 import './HashLink.scss';
 
 export interface HashLinkProps {
-  className?: string;
   id: string;
 }
 
-const HashLink: FC<HashLinkProps> = ({className, id}) => {
+const HashLink: SFC<HashLinkProps> = ({className, id}) => {
   return (
     <a className={clsx('HashLink', className)} data-testid="HashLink" href={`#${id}`}>
       #

--- a/src/components/Label/index.tsx
+++ b/src/components/Label/index.tsx
@@ -1,16 +1,16 @@
-import React, {FC} from 'react';
+import React from 'react';
 import clsx from 'clsx';
 
+import {SFC} from 'types/generic';
 import {isLight} from 'utils/colors';
 import './Label.scss';
 
 export interface LabelProps {
-  className?: string;
   color: string;
   name: string;
 }
 
-const Label: FC<LabelProps> = ({className, color, name}) => {
+const Label: SFC<LabelProps> = ({className, color, name}) => {
   const hexColor = `#${color}`;
 
   return (

--- a/src/components/LabelFilter/index.tsx
+++ b/src/components/LabelFilter/index.tsx
@@ -1,11 +1,11 @@
-import React, {FC} from 'react';
+import React from 'react';
 import clsx from 'clsx';
 
 import {Label} from 'components';
+import {SFC} from 'types/generic';
 import './LabelFilter.scss';
 
 export interface LabelFilterProps {
-  className?: string;
   handleLabelClick(labelName: string): () => void;
   selectedLabelNames: string[];
 }
@@ -21,7 +21,7 @@ const LABEL_COLORS = {
 
 const DEFAULT_LABEL_COLOR = 'e3e8ee';
 
-const LabelFilter: FC<LabelFilterProps> = ({className, handleLabelClick, selectedLabelNames}) => {
+const LabelFilter: SFC<LabelFilterProps> = ({className, handleLabelClick, selectedLabelNames}) => {
   const renderLabels = () => {
     return Object.entries(LABEL_COLORS).map(([labelName, hexColor]) => (
       <button

--- a/src/components/Layout/Layout.test.tsx
+++ b/src/components/Layout/Layout.test.tsx
@@ -7,20 +7,18 @@ import {createMemoryHistory} from 'history';
 
 import store from 'store';
 
-import Layout, {LayoutProps} from '.';
+import Layout from '.';
 
 const Wrapper: FC = ({children}) => <Provider store={store}>{children}</Provider>;
 
-const baseProps: LayoutProps = {
-  children: (
-    <>
-      <h1>Hello World!</h1>
-      <div id="tnb" data-testid="hash-test">
-        Hello TNB!
-      </div>
-    </>
-  ),
-};
+const testNode = (
+  <>
+    <h1>Hello World!</h1>
+    <div id="tnb" data-testid="hash-test">
+      Hello TNB!
+    </div>
+  </>
+);
 
 describe('Layout component', () => {
   beforeAll(() => {
@@ -37,7 +35,7 @@ describe('Layout component', () => {
     const history = createMemoryHistory();
     render(
       <Router history={history}>
-        <Layout {...baseProps} />
+        <Layout>{testNode}</Layout>
       </Router>,
       {wrapper: Wrapper},
     );
@@ -49,7 +47,7 @@ describe('Layout component', () => {
     const history = createMemoryHistory();
     render(
       <Router history={history}>
-        <Layout {...baseProps} />
+        <Layout>{testNode}</Layout>
       </Router>,
       {wrapper: Wrapper},
     );
@@ -62,7 +60,7 @@ describe('Layout component', () => {
     const history = createMemoryHistory();
     render(
       <Router history={history}>
-        <Layout {...baseProps} />
+        <Layout>{testNode}</Layout>
       </Router>,
       {wrapper: Wrapper},
     );
@@ -75,7 +73,7 @@ describe('Layout component', () => {
     history.push('/home#tnb');
     render(
       <Router history={history}>
-        <Layout {...baseProps} />
+        <Layout>{testNode}</Layout>
       </Router>,
       {wrapper: Wrapper},
     );

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -1,16 +1,13 @@
-import React, {FC, ReactNode, useEffect} from 'react';
+import React, {useEffect} from 'react';
 import {useLocation} from 'react-router-dom';
 
 import {Container, GoToTop} from 'components';
 import Footer from 'containers/Footer';
 import TopNav from 'containers/TopNav';
+import {SFC} from 'types/generic';
 import './Layout.scss';
 
-export interface LayoutProps {
-  children: ReactNode;
-}
-
-const Layout: FC<LayoutProps> = ({children}) => {
+const Layout: SFC = ({children}) => {
   const {hash, pathname} = useLocation();
 
   useEffect(() => {

--- a/src/components/Loader/index.tsx
+++ b/src/components/Loader/index.tsx
@@ -1,14 +1,11 @@
-import React, {FC, memo} from 'react';
+import React, {memo} from 'react';
 import clsx from 'clsx';
 import {Icon, IconType} from '@thenewboston/ui';
+import {SFC} from 'types/generic';
 
 import './Loader.scss';
 
-interface ComponentProps {
-  className?: string;
-}
-
-const Loader: FC<ComponentProps> = ({className}) => {
+const Loader: SFC = ({className}) => {
   return <Icon className={clsx('Loader', className)} icon={IconType.loading} size={15.35} dataTestId="Loader" />;
 };
 

--- a/src/components/MarketingButton/index.tsx
+++ b/src/components/MarketingButton/index.tsx
@@ -1,8 +1,9 @@
-import React, {FC} from 'react';
+import React from 'react';
 import clsx from 'clsx';
 import {bemify} from '@thenewboston/utils';
 
 import {A} from 'components';
+import {SFC} from 'types/generic';
 import {SocialMedia} from 'types/social-media';
 import {socialMediaUrls} from 'utils/social-media';
 
@@ -20,12 +21,11 @@ import YouTubeLogo from './logos/YouTubeLogo.png';
 import './MarketingButton.scss';
 
 interface ComponentProps {
-  className?: string;
   customLink?: string;
   website: SocialMedia;
 }
 
-const MarketingButton: FC<ComponentProps> = ({className, customLink, website}) => {
+const MarketingButton: SFC<ComponentProps> = ({className, customLink, website}) => {
   const renderImage = (src: any) => (
     <img
       alt={website}

--- a/src/components/MarketingCard/index.tsx
+++ b/src/components/MarketingCard/index.tsx
@@ -1,8 +1,9 @@
-import React, {FC} from 'react';
+import React from 'react';
 import clsx from 'clsx';
 import {bemify} from '@thenewboston/utils';
 
 import {A} from 'components';
+import {SFC} from 'types/generic';
 import {SocialMedia} from 'types/social-media';
 import {socialMediaDescriptions, socialMediaHandles, socialMediaUrls} from 'utils/social-media';
 
@@ -20,12 +21,11 @@ import YouTubeLogo from 'assets/logos/YouTube.png';
 import './MarketingCard.scss';
 
 export interface MarketingCardProps {
-  className?: string;
   customLink?: string;
   website: SocialMedia;
 }
 
-const MarketingCard: FC<MarketingCardProps> = ({className, customLink, website}) => {
+const MarketingCard: SFC<MarketingCardProps> = ({className, customLink, website}) => {
   const renderImage = (src: any) => (
     <img
       alt={website}

--- a/src/components/MenuGroup/index.tsx
+++ b/src/components/MenuGroup/index.tsx
@@ -1,8 +1,9 @@
-import React, {FC, useState} from 'react';
+import React, {useState} from 'react';
 import {RouteComponentProps, withRouter} from 'react-router-dom';
 import clsx from 'clsx';
 import {Icon, IconType} from '@thenewboston/ui';
 
+import {SFC} from 'types/generic';
 import {getFirstPathParam, getFirstThreePathParams} from 'utils/urls';
 
 import './MenuGroup.scss';
@@ -13,13 +14,13 @@ interface ComponentProps extends RouteComponentProps {
   role?: string;
 }
 
-const MenuGroup: FC<ComponentProps> = ({children, role, location, title, urlBase}) => {
+const MenuGroup: SFC<ComponentProps> = ({children, className, role, location, title, urlBase}) => {
   const [expanded, toggleExpanded] = useState(
     getFirstPathParam(location.pathname) === urlBase || getFirstThreePathParams(location.pathname) === urlBase,
   );
 
   return (
-    <div className="MenuGroup" data-testid="MenuGroup" role={role}>
+    <div className={clsx('MenuGroup', className)} data-testid="MenuGroup" role={role}>
       <button
         className={clsx('MenuGroup__toggle', {'MenuGroup__toggle--expanded': expanded})}
         onClick={() => toggleExpanded(!expanded)}

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -1,4 +1,4 @@
-import React, {CSSProperties, FC, ReactNode, useCallback, useEffect, useMemo} from 'react';
+import React, {CSSProperties, ReactNode, useCallback, useEffect, useMemo} from 'react';
 import {createPortal} from 'react-dom';
 import clsx from 'clsx';
 import noop from 'lodash/noop';
@@ -8,17 +8,16 @@ import {bemify} from '@thenewboston/utils';
 import {Form, FormButton, FormButtonProps} from 'components/FormComponents';
 import Loader from 'components/FormElements/Loader';
 import {GenericFormValues} from 'types/forms';
-import {GenericFunction} from 'types/generic';
+import {ClassName, GenericFunction, SFC} from 'types/generic';
 
 import './Modal.scss';
 
-export interface ModalButtonProps extends FormButtonProps {
+export interface ModalButtonProps extends FormButtonProps, ClassName {
   content: ReactNode;
 }
 
 interface ComponentProps {
   cancelButton?: ModalButtonProps | string;
-  className?: string;
   close(): void;
   footer?: ReactNode;
   header?: ReactNode;
@@ -31,7 +30,7 @@ interface ComponentProps {
   validationSchema?: any;
 }
 
-const Modal: FC<ComponentProps> = ({
+const Modal: SFC<ComponentProps> = ({
   cancelButton,
   children,
   className,

--- a/src/components/Navigation/index.tsx
+++ b/src/components/Navigation/index.tsx
@@ -1,7 +1,8 @@
-import React, {FC, useState} from 'react';
-
-import {Icon, IconType} from '@thenewboston/ui';
+import React, {useState} from 'react';
 import {useHistory} from 'react-router';
+import clsx from 'clsx';
+import {Icon, IconType} from '@thenewboston/ui';
+import {SFC} from 'types/generic';
 
 import './Navigation.scss';
 
@@ -11,13 +12,13 @@ type Props = {
   text: string;
 };
 
-const Navigation: FC<Props> = ({text, type, path}) => {
+const Navigation: SFC<Props> = ({className, text, type, path}) => {
   const history = useHistory();
   const [isHovered, setIsHovered] = useState(false);
 
   return (
     <div
-      className="Navigation"
+      className={clsx('Navigation', className)}
       onClick={() => history.push(path)}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}

--- a/src/components/Note/index.tsx
+++ b/src/components/Note/index.tsx
@@ -1,7 +1,8 @@
-import React, {FC, ReactNode} from 'react';
+import React, {ReactNode} from 'react';
 import clsx from 'clsx';
-
 import {Icon, IconType} from '@thenewboston/ui';
+import {SFC} from 'types/generic';
+
 import './Note.scss';
 
 export enum NoteType {
@@ -10,7 +11,6 @@ export enum NoteType {
 }
 
 type Props = {
-  className?: string;
   text: ReactNode;
   type: NoteType;
 };
@@ -20,7 +20,7 @@ const TYPE_TO_ICON_AND_TITLE_MAPPING: Record<NoteType, {icon: IconType; title: s
   [NoteType.Information]: {icon: IconType.pencil, title: 'Note'},
 };
 
-const Note: FC<Props> = ({className, text, type}) => {
+const Note: SFC<Props> = ({className, text, type}) => {
   const {icon, title} = TYPE_TO_ICON_AND_TITLE_MAPPING[type];
   return (
     <div className={clsx(`Note Note--${type}`, className)}>

--- a/src/components/PageTitle/index.tsx
+++ b/src/components/PageTitle/index.tsx
@@ -1,13 +1,14 @@
-import React, {FC} from 'react';
+import React from 'react';
 import {Helmet} from 'react-helmet-async';
+import {SFC} from 'types/generic';
 
 export interface PageTitleProps {
-  title: string;
   ogDescription?: string;
   ogImageUrl?: string;
   ogTitle?: string;
   ogType?: 'website' | 'article' | 'profile' | 'book';
   ogUrl?: string;
+  title: string;
 }
 
 export const defaultOg = {
@@ -18,20 +19,22 @@ export const defaultOg = {
   url: 'https://www.thenewboston.com/',
 };
 
-const PageTitle: FC<PageTitleProps> = ({
-  title,
+const PageTitle: SFC<PageTitleProps> = ({
   ogDescription = defaultOg.description,
   ogImageUrl = defaultOg.imageUrl,
-  ogTitle = `${title} | thenewboston`,
+  ogTitle,
   ogType = defaultOg.type,
   ogUrl = defaultOg.url,
+  title,
 }) => {
+  const titleToUse = `${title} | thenewboston`;
+  const ogTitleToUse = ogTitle || titleToUse;
   return (
     <Helmet>
-      <title>{title} | thenewboston</title>
+      <title>{titleToUse}</title>
       <meta name="description" property="og:description" content={ogDescription} />
       <meta property="og:image" content={ogImageUrl} />
-      <meta property="og:title" content={ogTitle} />
+      <meta property="og:title" content={ogTitleToUse} />
       <meta property="og:type" content={ogType} />
       <meta property="og:url" content={ogUrl} />
     </Helmet>

--- a/src/components/Pagination/index.tsx
+++ b/src/components/Pagination/index.tsx
@@ -1,7 +1,9 @@
-import React, {FC} from 'react';
+import React from 'react';
 import {NavLink, useLocation} from 'react-router-dom';
+import clsx from 'clsx';
 import {Icon, IconType} from '@thenewboston/ui';
 
+import {SFC} from 'types/generic';
 import {NavigationItem} from 'types/navigation';
 import './Pagination.scss';
 
@@ -9,7 +11,7 @@ export interface PaginationProps {
   navigationData: NavigationItem[];
 }
 
-const Pagination: FC<PaginationProps> = ({navigationData}) => {
+const Pagination: SFC<PaginationProps> = ({className, navigationData}) => {
   const location = useLocation();
 
   const renderNextLink = () => {
@@ -37,7 +39,7 @@ const Pagination: FC<PaginationProps> = ({navigationData}) => {
   };
 
   return (
-    <div className="Pagination" data-testid="Pagination">
+    <div className={clsx('Pagination', className)} data-testid="Pagination">
       {renderPreviousLink()}
       {renderNextLink()}
     </div>

--- a/src/components/Popover/Popover.test.tsx
+++ b/src/components/Popover/Popover.test.tsx
@@ -4,20 +4,16 @@ import {fireEvent, render, screen, waitFor} from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import {createMemoryHistory} from 'history';
 
+import {ClassName} from 'types/generic';
 import Popover, {PopoverProps} from '.';
 
 const history = createMemoryHistory();
 
 const Wrapper: FC = ({children}) => <Router history={history}>{children}</Router>;
 
-const baseProps: PopoverProps = {
+const baseProps: PopoverProps & ClassName = {
   anchorEl: null,
   anchorOrigin: {horizontal: 'center', vertical: 'top'},
-  children: (
-    <p>
-      Popover content <Link to="/different-route">click me</Link>
-    </p>
-  ),
   className: 'Test',
   closePopover: jest.fn(),
   id: 'test-id',
@@ -25,6 +21,12 @@ const baseProps: PopoverProps = {
   transformOffset: {horizontal: 0, vertical: 12},
   transformOrigin: {horizontal: 'center', vertical: 'top'},
 };
+
+const TestContent = (
+  <p>
+    Popover content <Link to="/different-route">click me</Link>
+  </p>
+);
 
 describe('Popover component', () => {
   beforeAll(() => {
@@ -37,13 +39,13 @@ describe('Popover component', () => {
   afterEach(() => jest.clearAllMocks());
 
   it('renders without crashing', () => {
-    render(<Popover {...baseProps} />, {wrapper: Wrapper});
+    render(<Popover {...baseProps}>{TestContent}</Popover>, {wrapper: Wrapper});
 
     expect(screen.getByTestId('Popover')).toBeTruthy();
   });
 
   it('renders with default className', () => {
-    render(<Popover {...baseProps} />, {wrapper: Wrapper});
+    render(<Popover {...baseProps}>{TestContent}</Popover>, {wrapper: Wrapper});
 
     expect(screen.getByTestId('Popover')).toHaveClass('Popover');
     expect(screen.getByTestId('Popover')).toHaveClass('Popover--open');
@@ -51,7 +53,7 @@ describe('Popover component', () => {
 
   it('renders with default className--open when open is passed in as true', () => {
     const props = {...baseProps, open: true};
-    render(<Popover {...props} />, {wrapper: Wrapper});
+    render(<Popover {...props}>{TestContent}</Popover>, {wrapper: Wrapper});
 
     expect(screen.getByTestId('Popover')).toHaveClass('Popover--open');
   });
@@ -65,25 +67,25 @@ describe('Popover component', () => {
 
   it('renders with className--open when open is passed in as true', () => {
     const props = {...baseProps, open: true};
-    render(<Popover {...props} />, {wrapper: Wrapper});
+    render(<Popover {...props}>{TestContent}</Popover>, {wrapper: Wrapper});
 
     expect(screen.getByTestId('Popover')).toHaveClass('Test--open');
   });
 
   it('renders children correctly', () => {
-    render(<Popover {...baseProps} />, {wrapper: Wrapper});
+    render(<Popover {...baseProps}>{TestContent}</Popover>, {wrapper: Wrapper});
 
     expect(screen.getByTestId('Popover').firstChild).toHaveTextContent('Popover content');
   });
 
   it('renders element with id passed in', () => {
-    render(<Popover {...baseProps} />, {wrapper: Wrapper});
+    render(<Popover {...baseProps}>{TestContent}</Popover>, {wrapper: Wrapper});
 
     expect(screen.getByTestId('Popover')).toHaveAttribute('id', baseProps.id);
   });
 
   it('closes popover on route change', async () => {
-    render(<Popover {...baseProps} />, {wrapper: Wrapper});
+    render(<Popover {...baseProps}>{TestContent}</Popover>, {wrapper: Wrapper});
 
     await waitFor(() => expect(baseProps.closePopover).toHaveBeenCalledTimes(1));
     screen.getByText('click me').click();
@@ -91,7 +93,7 @@ describe('Popover component', () => {
   });
 
   it('closes popover on scroll', async () => {
-    render(<Popover {...baseProps} />, {wrapper: Wrapper});
+    render(<Popover {...baseProps}>{TestContent}</Popover>, {wrapper: Wrapper});
 
     // When running multiple tests, the last `expect(...)` gets called more than once.
     // Adding the `jest.resetAllMocks()` to ensure the `closePopover` is called after scroll event.

--- a/src/components/Popover/index.tsx
+++ b/src/components/Popover/index.tsx
@@ -1,4 +1,4 @@
-import React, {FC, ReactNode, useEffect, useMemo, useRef, useState} from 'react';
+import React, {useEffect, useMemo, useRef, useState} from 'react';
 import {createPortal} from 'react-dom';
 import {useLocation} from 'react-router-dom';
 import clsx from 'clsx';
@@ -6,6 +6,7 @@ import throttle from 'lodash/throttle';
 import {bemify} from '@thenewboston/utils';
 
 import {useEventListener, useWindowDimensions} from 'hooks';
+import {SFC} from 'types/generic';
 import './Popover.scss';
 
 interface DomRect {
@@ -23,8 +24,6 @@ const initialDomRect = {height: 0, left: 0, top: 0, width: 0};
 export interface PopoverProps {
   anchorOrigin?: {horizontal: HorizontalPosition | number; vertical: VerticalPosition | number};
   anchorEl: HTMLElement | null;
-  children: ReactNode;
-  className?: string;
   closePopover(): void;
   id?: string;
   open: boolean;
@@ -32,7 +31,7 @@ export interface PopoverProps {
   transformOffset?: {horizontal: number; vertical: number};
 }
 
-const Popover: FC<PopoverProps> = ({
+const Popover: SFC<PopoverProps> = ({
   anchorEl,
   anchorOrigin = {horizontal: 'left', vertical: 'top'},
   children,

--- a/src/components/ProgressBar/index.tsx
+++ b/src/components/ProgressBar/index.tsx
@@ -1,15 +1,15 @@
-import React, {FC} from 'react';
+import React from 'react';
 import clsx from 'clsx';
+import {SFC} from 'types/generic';
 
 import './ProgressBar.scss';
 
 type Props = {
-  className?: string;
   height?: number;
   percentage: number;
 };
 
-const ProgressBar: FC<Props> = ({className, height, percentage}) => {
+const ProgressBar: SFC<Props> = ({className, height, percentage}) => {
   return (
     <div className={clsx(className, 'ProgressBar__bar')} style={{height}}>
       <div

--- a/src/components/ProgressiveImage/index.tsx
+++ b/src/components/ProgressiveImage/index.tsx
@@ -1,20 +1,21 @@
 import React, {useState} from 'react';
 import clsx from 'clsx';
+import {SFC} from 'types/generic';
 
 import './ProgressiveImage.scss';
 
 type Props = {
   alt: string;
+  containerClassName?: string;
+  height?: number;
+  placeholderImageClassName?: string;
   placeholderSrc: string; // src to a much smaller version of the real image
+  realImageClassName?: string;
   realSrc: string;
   width?: number;
-  height?: number;
-  containerClassName?: string;
-  placeholderImageClassName?: string;
-  realImageClassName?: string;
 };
 
-const ProgressiveImage = ({
+const ProgressiveImage: SFC<Props> = ({
   alt,
   containerClassName,
   height,
@@ -23,7 +24,7 @@ const ProgressiveImage = ({
   realImageClassName,
   realSrc,
   width,
-}: Props) => {
+}) => {
   const [isLoaded, setIsLoaded] = useState(false);
   return (
     <div className={clsx('ProgressiveImage', containerClassName)} style={{height, width}}>

--- a/src/components/Qr/index.tsx
+++ b/src/components/Qr/index.tsx
@@ -1,15 +1,15 @@
-import React, {FC, ReactNode, useEffect, useState} from 'react';
+import React, {ReactNode, useEffect, useState} from 'react';
 import clsx from 'clsx';
 import QrCode from 'qrcode';
+import {SFC} from 'types/generic';
 
 interface ComponentProps {
-  className?: string;
   margin?: number;
   text: string;
   width?: number;
 }
 
-const Qr: FC<ComponentProps> = ({className, margin = 0, text, width = 140}) => {
+const Qr: SFC<ComponentProps> = ({className, margin = 0, text, width = 140}) => {
   const [qr, setQr] = useState<ReactNode | null>(null);
 
   useEffect(() => {

--- a/src/components/QueryParams/QueryParamsOffsetAndLimit/index.tsx
+++ b/src/components/QueryParams/QueryParamsOffsetAndLimit/index.tsx
@@ -1,4 +1,5 @@
-import React, {FC} from 'react';
+import React from 'react';
+import {SFC} from 'types/generic';
 
 import {TableParams} from 'components';
 
@@ -6,7 +7,7 @@ interface ComponentProps {
   returnedEntityName: string;
 }
 
-const QueryParamsOffsetAndLimit: FC<ComponentProps> = ({returnedEntityName}) => {
+const QueryParamsOffsetAndLimit: SFC<ComponentProps> = ({returnedEntityName}) => {
   return (
     <TableParams
       items={[

--- a/src/components/RequiredAsterisk/index.tsx
+++ b/src/components/RequiredAsterisk/index.tsx
@@ -1,13 +1,10 @@
-import React, {FC, memo} from 'react';
+import React, {memo} from 'react';
 import clsx from 'clsx';
+import {SFC} from 'types/generic';
 
 import './RequiredAsterisk.scss';
 
-interface ComponentProps {
-  className?: string;
-}
-
-const RequiredAsterisk: FC<ComponentProps> = ({className}) => {
+const RequiredAsterisk: SFC = ({className}) => {
   return (
     <span data-testid="RequiredAsterisk" className={clsx('RequiredAsterisk', className)}>
       *

--- a/src/components/Shadow/index.tsx
+++ b/src/components/Shadow/index.tsx
@@ -1,7 +1,9 @@
-import React, {FC} from 'react';
+import React from 'react';
+import clsx from 'clsx';
+import {SFC} from 'types/generic';
 
 import './Shadow.scss';
 
-const Shadow: FC = () => <div className="Shadow" />;
+const Shadow: SFC = ({className}) => <div className={clsx('Shadow', className)} />;
 
 export default Shadow;

--- a/src/components/SlideUp/index.tsx
+++ b/src/components/SlideUp/index.tsx
@@ -1,16 +1,16 @@
-import React, {FC} from 'react';
+import React from 'react';
 import {createPortal} from 'react-dom';
 import clsx from 'clsx';
+import {SFC} from 'types/generic';
 import {bemify} from '@thenewboston/utils';
 
 import './SlideUp.scss';
 
 interface ComponentProps {
-  className?: string;
   close(): void;
 }
 
-const SlideUp: FC<ComponentProps> = ({children, className, close}) => {
+const SlideUp: SFC<ComponentProps> = ({children, className, close}) => {
   return createPortal(
     <>
       <div className="SlideUp__overlay" onClick={close} role="button" tabIndex={0} data-testid="SlideUp__overlay" />

--- a/src/components/SocialMediaIcon/index.tsx
+++ b/src/components/SocialMediaIcon/index.tsx
@@ -1,19 +1,19 @@
-import React, {FC} from 'react';
+import React from 'react';
 import clsx from 'clsx';
 import {Icon, IconType} from '@thenewboston/ui';
 
 import {A} from 'components';
+import {SFC} from 'types/generic';
 import {SocialMedia} from 'types/social-media';
 import {socialMediaUrls} from 'utils/social-media';
 
 interface ComponentProps {
-  className?: string;
   iconSize: number;
   totalSize: number;
   website: SocialMedia;
 }
 
-const SocialMediaIcon: FC<ComponentProps> = ({className, iconSize, totalSize, website}) => {
+const SocialMediaIcon: SFC<ComponentProps> = ({className, iconSize, totalSize, website}) => {
   return (
     <A className={clsx('SocialMediaIcon', className)} href={socialMediaUrls[website]}>
       <Icon icon={IconType[website] as IconType} size={iconSize} totalSize={totalSize} />

--- a/src/components/StepIndicator/index.tsx
+++ b/src/components/StepIndicator/index.tsx
@@ -1,16 +1,16 @@
-import React, {FC, memo, ReactNode} from 'react';
+import React, {memo, ReactNode} from 'react';
 import clsx from 'clsx';
 import {bemify} from '@thenewboston/utils';
+import {SFC} from 'types/generic';
 
 import './StepIndicator.scss';
 
 export interface StepIndicatorProps {
-  className?: string;
   number: number;
   text: ReactNode;
 }
 
-const StepIndicator: FC<StepIndicatorProps> = ({className, number, text}) => {
+const StepIndicator: SFC<StepIndicatorProps> = ({className, number, text}) => {
   return (
     <div className={clsx('StepIndicator', className)} data-testid="StepIndicator">
       <div

--- a/src/components/Table/TableBorderGrid/TableBorderGrid.test.tsx
+++ b/src/components/Table/TableBorderGrid/TableBorderGrid.test.tsx
@@ -2,9 +2,10 @@ import React from 'react';
 import {render, screen} from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
+import {ClassName} from 'types/generic';
 import TableBorderGrid, {TableBorderGridProps} from '.';
 
-const baseProps: TableBorderGridProps = {
+const baseProps: TableBorderGridProps & ClassName = {
   className: 'Test',
   headers: ['Head 1', 'Head 2'],
   rows: [

--- a/src/components/Table/TableBorderGrid/index.tsx
+++ b/src/components/Table/TableBorderGrid/index.tsx
@@ -1,17 +1,17 @@
-import React, {FC, ReactNode} from 'react';
+import React, {ReactNode} from 'react';
 import clsx from 'clsx';
 import {bemify} from '@thenewboston/utils';
+import {SFC} from 'types/generic';
 
 import './TableBorderGrid.scss';
 
 export interface TableBorderGridProps {
-  className?: string;
   headers?: ReactNode[];
   rows: ReactNode[][];
   title?: ReactNode;
 }
 
-const TableBorderGrid: FC<TableBorderGridProps> = ({className, headers, rows, title}) => {
+const TableBorderGrid: SFC<TableBorderGridProps> = ({className, headers, rows, title}) => {
   const renderBody = (): ReactNode => {
     return (
       <tbody className={clsx('TableBorderGrid__tbody', {...bemify(className, '__tbody')})}>

--- a/src/components/Table/TableParams/index.tsx
+++ b/src/components/Table/TableParams/index.tsx
@@ -1,6 +1,7 @@
-import React, {FC, ReactNode} from 'react';
+import React, {ReactNode} from 'react';
 import clsx from 'clsx';
 import {bemify} from '@thenewboston/utils';
+import {SFC} from 'types/generic';
 
 import './TableParams.scss';
 
@@ -12,12 +13,11 @@ interface Item {
 }
 
 interface ComponentProps {
-  className?: string;
   headers?: ReactNode[];
   items: Item[];
 }
 
-const TableParams: FC<ComponentProps> = ({className, headers, items}) => {
+const TableParams: SFC<ComponentProps> = ({className, headers, items}) => {
   const renderBody = (): ReactNode => {
     return (
       <tbody className={clsx('TableParams__tbody', {...bemify(className, '__tbody')})} data-testid="TableParams__tbody">

--- a/src/components/Table/TableVertical/TableVertical.test.tsx
+++ b/src/components/Table/TableVertical/TableVertical.test.tsx
@@ -2,9 +2,10 @@ import React from 'react';
 import {render, screen} from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
+import {ClassName} from 'types/generic';
 import TableVertical, {TableVerticalProps} from '.';
 
-const baseProps: TableVerticalProps = {
+const baseProps: TableVerticalProps & ClassName = {
   className: 'Test',
   rows: [
     ['Row 1 Column 1', 'Row 1 Column 2'],

--- a/src/components/Table/TableVertical/index.tsx
+++ b/src/components/Table/TableVertical/index.tsx
@@ -1,17 +1,17 @@
-import React, {FC, ReactNode} from 'react';
+import React, {ReactNode} from 'react';
 import clsx from 'clsx';
 import {bemify} from '@thenewboston/utils';
+import {SFC} from 'types/generic';
 
 import './TableVertical.scss';
 
 export interface TableVerticalProps {
   altColors?: boolean;
-  className?: string;
   innerBorders?: boolean;
   rows: ReactNode[][];
 }
 
-const TableVertical: FC<TableVerticalProps> = ({altColors = false, className, innerBorders = false, rows}) => {
+const TableVertical: SFC<TableVerticalProps> = ({altColors = false, className, innerBorders = false, rows}) => {
   const renderBody = (): ReactNode => {
     return (
       <tbody

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -1,5 +1,6 @@
-import React, {FC, ReactNode, useState} from 'react';
+import React, {ReactNode, useState} from 'react';
 import clsx from 'clsx';
+import {SFC} from 'types/generic';
 
 import './Tabs.scss';
 
@@ -14,7 +15,7 @@ export interface TabsProps {
   latestReleaseNumber: number | null;
 }
 
-const Tabs: FC<TabsProps> = ({defaultTab = 0, tabs, latestReleaseNumber}) => {
+const Tabs: SFC<TabsProps> = ({className, defaultTab = 0, tabs, latestReleaseNumber}) => {
   const [activeTab, setActiveTab] = useState<number>(defaultTab);
 
   const renderTabs = (): ReactNode => {
@@ -41,7 +42,7 @@ const Tabs: FC<TabsProps> = ({defaultTab = 0, tabs, latestReleaseNumber}) => {
   };
 
   return (
-    <div className="Tabs" data-testid="Tabs">
+    <div className={clsx('Tabs', className)} data-testid="Tabs">
       {renderTabs()}
       <p
         className="Download__latest-version"

--- a/src/components/TimeFilter/index.tsx
+++ b/src/components/TimeFilter/index.tsx
@@ -1,18 +1,17 @@
-import React, {FC} from 'react';
+import React from 'react';
 import clsx from 'clsx';
 
-import {GenericVoidFunction} from 'types/generic';
+import {GenericVoidFunction, SFC} from 'types/generic';
 import {Time, TimeFilterType} from 'types/github';
 
 import './TimeFilter.scss';
 
 export interface TimeFilterProps {
-  className?: string;
   selectedFilter: TimeFilterType;
   setSelectedFilter: GenericVoidFunction;
 }
 
-const TimeFilter: FC<TimeFilterProps> = ({className, selectedFilter, setSelectedFilter}) => {
+const TimeFilter: SFC<TimeFilterProps> = ({className, selectedFilter, setSelectedFilter}) => {
   const handleOptionClick = (i: TimeFilterType): GenericVoidFunction => (): void => {
     setSelectedFilter(i);
   };

--- a/src/components/Toast/index.tsx
+++ b/src/components/Toast/index.tsx
@@ -1,18 +1,18 @@
-import React, {FC, useMemo} from 'react';
+import React, {useMemo} from 'react';
 import clsx from 'clsx';
 import {Icon, IconType} from '@thenewboston/ui';
 import {bemify} from '@thenewboston/utils';
+import {SFC} from 'types/generic';
 
 import './Toast.scss';
 
 export type ToastType = 'success' | 'warning';
 
 interface ComponentProps {
-  className?: string;
   type: ToastType;
 }
 
-const Toast: FC<ComponentProps> = ({children, className, type = 'warning'}) => {
+const Toast: SFC<ComponentProps> = ({children, className, type = 'warning'}) => {
   const iconType = useMemo<IconType>(() => {
     switch (type) {
       case 'success':

--- a/src/components/TotalAmount/index.tsx
+++ b/src/components/TotalAmount/index.tsx
@@ -1,16 +1,16 @@
-import React, {FC} from 'react';
+import React from 'react';
 import clsx from 'clsx';
 import {bemify} from '@thenewboston/utils';
+import {SFC} from 'types/generic';
 
 import './TotalAmount.scss';
 
 interface ComponentProps {
   amount: number;
-  className?: string;
   title: string;
 }
 
-const TotalAmount: FC<ComponentProps> = ({amount, className, title}) => {
+const TotalAmount: SFC<ComponentProps> = ({amount, className, title}) => {
   return (
     <div className={clsx('TotalAmount', className)} data-testid="TotalAmount">
       <div className={clsx('TotalAmount__title', {...bemify(className, '__title')})} data-testid="TotalAmount__title">

--- a/src/components/VideoPlayer/index.tsx
+++ b/src/components/VideoPlayer/index.tsx
@@ -1,16 +1,16 @@
-import React, {FC} from 'react';
+import React from 'react';
 import ReactPlayerYouTube from 'react-player/youtube';
 import ReactPlayerVimeo from 'react-player/vimeo';
 import clsx from 'clsx';
 import {bemify} from '@thenewboston/utils';
 
+import {SFC} from 'types/generic';
 import {Source} from 'types/tutorials';
 import {getVideoUrl} from 'utils/urls';
 
 import './VideoPlayer.scss';
 
 interface VideoPlayerProps {
-  className?: string;
   controls?: boolean;
   onEnded?(): void;
   playing?: boolean;
@@ -18,7 +18,7 @@ interface VideoPlayerProps {
   videoId: string;
 }
 
-const VideoPlayer: FC<VideoPlayerProps> = ({className, controls = true, onEnded, playing = true, source, videoId}) => {
+const VideoPlayer: SFC<VideoPlayerProps> = ({className, controls = true, onEnded, playing = true, source, videoId}) => {
   return (
     <div className={clsx('VideoPlayer', className)}>
       {source === Source.youtube ? (

--- a/src/types/generic.ts
+++ b/src/types/generic.ts
@@ -1,3 +1,9 @@
+import {FC} from 'react';
+
+export interface ClassName {
+  className?: string;
+}
+
 export interface Dict<T> {
   [key: string]: T;
 }
@@ -7,3 +13,5 @@ type GenericFunctionConstructor<T> = (...args: any[]) => T;
 export type GenericFunction = GenericFunctionConstructor<any>;
 
 export type GenericVoidFunction = GenericFunctionConstructor<void | Promise<void>>;
+
+export type SFC<P = Record<string, unknown>> = FC<P & ClassName>;


### PR DESCRIPTION
the `container` files need them as well, but then I got lazy. We can put that in the backlog.

One thought i have had while working on the Wallet app. Styled Components uses the `className` prop to perform the magic of being able to style other StyledComponents from the reference of a parent component (https://styled-components.com/docs/basics#styling-any-component)

Let me try to explain what happened with an example. suppose we have two components:

`const Child = ({className}) => <div className={className}>...</div>`
`const Parent = () => <div><S.Child /></div>`

within the `Parent`'s `Styled` file, I add styling to the `Child` like so:

```
import UChild from './Child';

export const Child = styled(UChild)`
   background: pink;
`
```

Therefore, whenever the `<S.Child />` is rendered within the `<Parent />`, it turns pink.

So I did something like this, and after awhile, I thought (mistakenly) that `Child` component does not need the `className` component (I must've forgotten how styled-components work, but even if I did remember, it is not so obvious which component is being styled from a parent component, and which aren't), and so I removed it. The `<S.Child />`, therefore, was no longer pink. But I was unaware of this for quite awhile, until I noticed finally that the UI was busted (with pink it is obvious, but my issue was more subtle, dealing with margins).

`Styled-Components` gives no indication that there is some styling that has been defined, but because of the absense of `className`, it is not put into effect. This is quite alarming, since it may potentially mean that some styles goes unapplied without our knowledge.

One way we can solve this dilemma is to enforce that all our `components` must have an optional `className` prop, and that `className` be put within the appropriate React Element. I'm not sure if there's a linting rule that enforces this though.

But I want you guys's thoughts. Hopefully you guys understand my worry?


