### PR TITLE
Fix/GitHub label issue

### DIFF
--- a/src/constants/regex.ts
+++ b/src/constants/regex.ts
@@ -1,1 +1,4 @@
-export const REGEX = {excludingNumber: /[^\d.]/g};
+export const REGEX = {
+  excludingNumber: /[^\d.]/g,
+  githubWeightedLabel: /PR\s\/[\d|\s|Task]+\/\s/g,
+};

--- a/src/constants/regex.ts
+++ b/src/constants/regex.ts
@@ -1,4 +1,5 @@
 export const REGEX = {
+  containsNumber: /[\d]/i,
   excludingNumber: /[^\d.]/g,
   githubWeightedLabel: /PR\s\/[\d|\s|Task]+\/\s/g,
 };


### PR DESCRIPTION
The issued was caused when I created a new PR label with the format `PR / <storypoint> / <bounty>`.

This created an issue where the website would parse the label to combine the `storypoint+bounty` into a single number.

whereby 
`PR / 2 / 2500` would parse the label as `22500`

before | after
--- | ---
<img width="1438" alt="Screenshot 2022-02-01 at 3 01 45 PM" src="https://user-images.githubusercontent.com/89671440/151929673-fc65c300-6e6c-4dd4-ad73-d0b5c10f2b99.png"> | <img width="1095" alt="Screenshot 2022-02-01 at 3 22 24 PM" src="https://user-images.githubusercontent.com/89671440/151927869-c0d29560-dfb6-4669-83fc-e08058edb566.png">  

